### PR TITLE
Add possibility to set direction of ORDER BY clause.

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -15,6 +15,7 @@ type deleteData struct {
 	From              string
 	WhereParts        whereParts
 	OrderBys          []string
+	Order             string
 	Limit             string
 	Offset            string
 	Suffixes          exprs
@@ -54,6 +55,10 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 	if len(d.OrderBys) > 0 {
 		sql.WriteString(" ORDER BY ")
 		sql.WriteString(strings.Join(d.OrderBys, ", "))
+
+		if len(d.Order) > 0 {
+			sql.WriteString(" " + d.Order)
+		}
 	}
 
 	if len(d.Limit) > 0 {
@@ -74,7 +79,6 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
 	return
 }
-
 
 // Builder
 
@@ -134,6 +138,16 @@ func (b DeleteBuilder) Where(pred interface{}, args ...interface{}) DeleteBuilde
 // OrderBy adds ORDER BY expressions to the query.
 func (b DeleteBuilder) OrderBy(orderBys ...string) DeleteBuilder {
 	return builder.Extend(b, "OrderBys", orderBys).(DeleteBuilder)
+}
+
+// Defines ascending order for ORDER BY statement.
+func (b DeleteBuilder) OrderAsc() DeleteBuilder {
+	return builder.Set(b, "Order", "ASC").(DeleteBuilder)
+}
+
+// Defines descending order for ORDER BY statement.
+func (b DeleteBuilder) OrderDesc() DeleteBuilder {
+	return builder.Set(b, "Order", "DESC").(DeleteBuilder)
 }
 
 // Limit sets a LIMIT clause on the query.

--- a/delete_test.go
+++ b/delete_test.go
@@ -12,6 +12,7 @@ func TestDeleteBuilderToSql(t *testing.T) {
 		From("a").
 		Where("b = ?", 1).
 		OrderBy("c").
+		OrderDesc().
 		Limit(2).
 		Offset(3).
 		Suffix("RETURNING ?", 4)
@@ -21,7 +22,7 @@ func TestDeleteBuilderToSql(t *testing.T) {
 
 	expectedSql :=
 		"WITH prefix AS ? " +
-			"DELETE FROM a WHERE b = ? ORDER BY c LIMIT 2 OFFSET 3 " +
+			"DELETE FROM a WHERE b = ? ORDER BY c DESC LIMIT 2 OFFSET 3 " +
 			"RETURNING ?"
 	assert.Equal(t, expectedSql, sql)
 

--- a/expr.go
+++ b/expr.go
@@ -5,7 +5,7 @@ import (
 )
 
 type expr struct {
-	sql string
+	sql  string
 	args []interface{}
 }
 

--- a/select.go
+++ b/select.go
@@ -19,6 +19,7 @@ type selectData struct {
 	GroupBys          []string
 	HavingParts       whereParts
 	OrderBys          []string
+	Order             string
 	Limit             string
 	Offset            string
 	Suffixes          exprs
@@ -95,6 +96,10 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 	if len(d.OrderBys) > 0 {
 		sql.WriteString(" ORDER BY ")
 		sql.WriteString(strings.Join(d.OrderBys, ", "))
+
+		if len(d.Order) > 0 {
+			sql.WriteString(" " + d.Order)
+		}
 	}
 
 	if len(d.Limit) > 0 {
@@ -230,6 +235,16 @@ func (b SelectBuilder) Having(pred interface{}, rest ...interface{}) SelectBuild
 // OrderBy adds ORDER BY expressions to the query.
 func (b SelectBuilder) OrderBy(orderBys ...string) SelectBuilder {
 	return builder.Extend(b, "OrderBys", orderBys).(SelectBuilder)
+}
+
+// Defines ascending order for ORDER BY statement.
+func (b SelectBuilder) OrderAsc() SelectBuilder {
+	return builder.Set(b, "Order", "ASC").(SelectBuilder)
+}
+
+// Defines descending order for ORDER BY statement.
+func (b SelectBuilder) OrderDesc() SelectBuilder {
+	return builder.Set(b, "Order", "DESC").(SelectBuilder)
 }
 
 // Limit sets a LIMIT clause on the query.

--- a/select_test.go
+++ b/select_test.go
@@ -19,6 +19,7 @@ func TestSelectBuilderToSql(t *testing.T) {
 		GroupBy("i").
 		Having("j = k").
 		OrderBy("l").
+		OrderAsc().
 		Limit(7).
 		Offset(8).
 		Suffix("FETCH FIRST ? ROWS ONLY", 7)
@@ -30,7 +31,7 @@ func TestSelectBuilderToSql(t *testing.T) {
 		"WITH prefix AS ? " +
 			"SELECT DISTINCT a, b, c FROM d " +
 			"WHERE e = ? AND f = ? AND g = ? AND h IN (?,?,?) " +
-			"GROUP BY i HAVING j = k ORDER BY l LIMIT 7 OFFSET 8 " +
+			"GROUP BY i HAVING j = k ORDER BY l ASC LIMIT 7 OFFSET 8 " +
 			"FETCH FIRST ? ROWS ONLY"
 	assert.Equal(t, expectedSql, sql)
 

--- a/update.go
+++ b/update.go
@@ -18,6 +18,7 @@ type updateData struct {
 	SetClauses        []setClause
 	WhereParts        whereParts
 	OrderBys          []string
+	Order             string
 	Limit             string
 	Offset            string
 	Suffixes          exprs
@@ -82,6 +83,10 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 	if len(d.OrderBys) > 0 {
 		sql.WriteString(" ORDER BY ")
 		sql.WriteString(strings.Join(d.OrderBys, ", "))
+
+		if len(d.Order) > 0 {
+			sql.WriteString(" " + d.Order)
+		}
 	}
 
 	if len(d.Limit) > 0 {
@@ -102,7 +107,6 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
 	return
 }
-
 
 // Builder
 
@@ -183,6 +187,16 @@ func (b UpdateBuilder) Where(pred interface{}, args ...interface{}) UpdateBuilde
 // OrderBy adds ORDER BY expressions to the query.
 func (b UpdateBuilder) OrderBy(orderBys ...string) UpdateBuilder {
 	return builder.Extend(b, "OrderBys", orderBys).(UpdateBuilder)
+}
+
+// Defines ascending order for ORDER BY statement.
+func (b UpdateBuilder) OrderAsc() UpdateBuilder {
+	return builder.Set(b, "Order", "ASC").(UpdateBuilder)
+}
+
+// Defines descending order for ORDER BY statement.
+func (b UpdateBuilder) OrderDesc() UpdateBuilder {
+	return builder.Set(b, "Order", "DESC").(UpdateBuilder)
 }
 
 // Limit sets a LIMIT clause on the query.

--- a/update_test.go
+++ b/update_test.go
@@ -14,6 +14,7 @@ func TestUpdateBuilderToSql(t *testing.T) {
 		SetMap(Eq{"c": 2}).
 		Where("d = ?", 3).
 		OrderBy("e").
+		OrderAsc().
 		Limit(4).
 		Offset(5).
 		Suffix("RETURNING ?", 6)
@@ -24,7 +25,7 @@ func TestUpdateBuilderToSql(t *testing.T) {
 	expectedSql :=
 		"WITH prefix AS ? " +
 			"UPDATE a SET b = ? + 1, c = ? WHERE d = ? " +
-			"ORDER BY e LIMIT 4 OFFSET 5 " +
+			"ORDER BY e ASC LIMIT 4 OFFSET 5 " +
 			"RETURNING ?"
 	assert.Equal(t, expectedSql, sql)
 


### PR DESCRIPTION
Hello!

Thanks for your query builder. Simple and lightweight :) Exactly what I need. Just one thing: it lacks possibility to control ORDER BY's direction (ASC or DESC). This pull request fixes the problem.

Cheers!
