### PR TITLE
expr: raise error when 0-len slice passed

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -57,6 +57,10 @@ func (eq Eq) ToSql() (sql string, args []interface{}, err error) {
 		} else {
 			valVal := reflect.ValueOf(val)
 			if valVal.Kind() == reflect.Array || valVal.Kind() == reflect.Slice {
+				if valVal.Len() == 0 {
+					err = fmt.Errorf("equality condition must contain at least one paramater")
+					return
+				}
 				placeholders := make([]string, valVal.Len())
 				for i := 0; i < valVal.Len(); i++ {
 					placeholders[i] = "?"

--- a/where_test.go
+++ b/where_test.go
@@ -1,6 +1,7 @@
 package squirrel
 
 import (
+	"fmt"
 	"testing"
 
 	"bytes"
@@ -53,4 +54,9 @@ func TestWherePartMap(t *testing.T) {
 	m := map[string]interface{}{"x": 1, "y": 2}
 	test(m)
 	test(Eq(m))
+}
+
+func TestWherePartNoArgs(t *testing.T) {
+	_, _, err := newWherePart(Eq{"test": []string{}}).ToSql()
+	assert.Equal(t, err, fmt.Errorf("equality condition must contain at least one paramater"))
 }


### PR DESCRIPTION
Addresses https://github.com/lann/squirrel/issues/25 - throws an error when there's an `Eq` passed in that contains a zero-length slice as a condition. Adds a small test to ensure that this is thrown, as well. 
