### PR TITLE
More flexible join clauses (string -> Sqlizer)

### DIFF
--- a/select.go
+++ b/select.go
@@ -15,7 +15,7 @@ type selectData struct {
 	Distinct          bool
 	Columns           []Sqlizer
 	From              string
-	Joins             []string
+	Joins             []Sqlizer
 	WhereParts        []Sqlizer
 	GroupBys          []string
 	HavingParts       []Sqlizer
@@ -83,7 +83,7 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Joins) > 0 {
 		sql.WriteString(" ")
-		sql.WriteString(strings.Join(d.Joins, " "))
+		args, err = appendToSql(d.Joins, sql, " ", args)
 	}
 
 	if len(d.WhereParts) > 0 {
@@ -219,23 +219,23 @@ func (b SelectBuilder) From(from string) SelectBuilder {
 }
 
 // JoinClause adds a join clause to the query.
-func (b SelectBuilder) JoinClause(join string) SelectBuilder {
-	return builder.Append(b, "Joins", join).(SelectBuilder)
+func (b SelectBuilder) JoinClause(pred interface{}, args ...interface{}) SelectBuilder {
+	return builder.Append(b, "Joins", newPart(pred, args...)).(SelectBuilder)
 }
 
 // Join adds a JOIN clause to the query.
-func (b SelectBuilder) Join(join string) SelectBuilder {
-	return b.JoinClause("JOIN " + join)
+func (b SelectBuilder) Join(join string, rest ...interface{}) SelectBuilder {
+	return b.JoinClause("JOIN "+join, rest...)
 }
 
 // LeftJoin adds a LEFT JOIN clause to the query.
-func (b SelectBuilder) LeftJoin(join string) SelectBuilder {
-	return b.JoinClause("LEFT JOIN " + join)
+func (b SelectBuilder) LeftJoin(join string, rest ...interface{}) SelectBuilder {
+	return b.JoinClause("LEFT JOIN "+join, rest...)
 }
 
 // RightJoin adds a RIGHT JOIN clause to the query.
-func (b SelectBuilder) RightJoin(join string) SelectBuilder {
-	return b.JoinClause("RIGHT JOIN " + join)
+func (b SelectBuilder) RightJoin(join string, rest ...interface{}) SelectBuilder {
+	return b.JoinClause("RIGHT JOIN "+join, rest...)
 }
 
 // Where adds an expression to the WHERE clause of the query.


### PR DESCRIPTION
I needed to join a nested select statement for a query I ran, so I did this change:

JoinClause now accepts an interface as first parameter and varadic arguments (like Where, etc.)
The sugar functions Join, LeftJoin, RightJoin still accept a string as first parameter (backwards compatibility ok), but also variadic arguments, so you can write e.g.

    Select(`*`).From(`foo`).Join(`bar ON foo.baz = bar.baz AND bar.fubar > ?`, 42)

The JoinClause signature is also backwards compatible (string -> interface + variadic), but it now allows you to pass any Sqlizer (again, like Where), so you can e.g.

    subselect := squirrel.Select(`*`).From(`foo`).Where(...)
    select := squirrel.Select(`*`).From(`bar`).JoinClause(subselect.Prefix(`LEFT JOIN (`).Suffix(`) r ON bar.baz = r .baz`))