### PR TITLE
Add SetColumns to SelectBuilder

### DIFF
--- a/select.go
+++ b/select.go
@@ -218,6 +218,11 @@ func (b SelectBuilder) Columns(columns ...string) SelectBuilder {
 	return builder.Extend(b, "Columns", parts).(SelectBuilder)
 }
 
+// SetColumns sets the columns in the query.
+func (b SelectBuilder) SetColumns(columns ...string) SelectBuilder {
+	return builder.Delete(b, "Columns").(SelectBuilder).Columns(columns...)
+}
+
 // Column adds a result column to the query.
 // Unlike Columns, Column accepts args which will be bound to placeholders in
 // the columns string, for example:

--- a/select_test.go
+++ b/select_test.go
@@ -162,3 +162,14 @@ func TestSelectWithOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT DISTINCT SQL_NO_CACHE * FROM foo", sql)
 }
+
+func TestSetColumns(t *testing.T) {
+	builder := Select("blarg").From("foo")
+	sql, _, err := builder.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT blarg FROM foo", sql)
+
+	sql, _, err = builder.SetColumns("biz", "baz").ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT biz, baz FROM foo", sql)
+}


### PR DESCRIPTION
We have a use-case where we need to be able to set the columns on a `SelectBuilder` after it has already been created.

Example:

```go
builder.SetColumns("biz", "baz")
```