### PR TITLE
Enforce order of columns and values when using SetMap

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"github.com/lann/builder"
+	"sort"
 	"strings"
+
+	"github.com/lann/builder"
 )
 
 type insertData struct {
@@ -194,11 +196,17 @@ func (b InsertBuilder) Suffix(sql string, args ...interface{}) InsertBuilder {
 // SetMap set columns and values for insert builder from a map of column name and value
 // note that it will reset all previous columns and values was set if any
 func (b InsertBuilder) SetMap(clauses map[string]interface{}) InsertBuilder {
+	// Keep the columns in a consistent order by sorting the column key string.
 	cols := make([]string, 0, len(clauses))
-	vals := make([]interface{}, 0, len(clauses))
-	for col, val := range clauses {
+	for col := range clauses {
 		cols = append(cols, col)
-		vals = append(vals, val)
+	}
+	sort.Strings(cols)
+
+	// Extract the values using columns.
+	vals := make([]interface{}, 0, len(clauses))
+	for _, col := range cols {
+		vals = append(vals, clauses[col])
 	}
 
 	b = builder.Set(b, "Columns", cols).(InsertBuilder)

--- a/insert_test.go
+++ b/insert_test.go
@@ -65,14 +65,14 @@ func TestInsertBuilderNoRunner(t *testing.T) {
 }
 
 func TestInsertBuilderSetMap(t *testing.T) {
-	b := Insert("table").SetMap(Eq{"field1": 1})
+	b := Insert("table").SetMap(Eq{"field1": 1, "field2": 2, "field3": 3})
 
 	sql, args, err := b.ToSql()
 	assert.NoError(t, err)
 
-	expectedSql := "INSERT INTO table (field1) VALUES (?)"
+	expectedSql := "INSERT INTO table (field1,field2,field3) VALUES (?,?,?)"
 	assert.Equal(t, expectedSql, sql)
 
-	expectedArgs := []interface{}{1}
+	expectedArgs := []interface{}{1, 2, 3}
 	assert.Equal(t, expectedArgs, args)
 }


### PR DESCRIPTION
I ran into an issue trying to mock a query using generated SQL due to the variability on the placement of arguments. 

This modified version of `TestInsertBuilderSetMap()` illustrates my issue:
```
func TestInsertBuilderSetMap(t *testing.T) {
	b := Insert("table").SetMap(Eq{"field1": 1, "field2": 2, "field3": 3})

	sql, args, err := b.ToSql()
	assert.NoError(t, err)

	expectedSql := "INSERT INTO table (field1,field2,field3) VALUES (?,?,?)"
	assert.Equal(t, expectedSql, sql)

	expectedArgs := []interface{}{1, 2, 3}
	assert.Equal(t, expectedArgs, args)
}
```

It yields `PASS` on some cases and in other cases it yields `FAIL` with this:
```
--- FAIL: TestInsertBuilderSetMap (0.00s)
        Error Trace:    insert_test.go:74
	Error:		Not equal:
			expected: "INSERT INTO table (field1,field2,field3) VALUES (?,?,?)"
			received: "INSERT INTO table (field3,field1,field2) VALUES (?,?,?)"

        Error Trace:    insert_test.go:77
	Error:		Not equal:
			expected: []interface {}{1, 2, 3}
			received: []interface {}{3, 1, 2}

			Diff:
			--- Expected
			+++ Actual
			@@ -1,5 +1,5 @@
			-([]interface {}) (len=3 cap=3) {
			+([]interface {}) (len=3 cap=4) {
			+ (int) 3,
			  (int) 1,
			- (int) 2,
			- (int) 3
			+ (int) 2
			 }

FAIL
exit status 1
```

This PR attempts to fix this by modifying `SetMap()` to sort the column keys prior to SQL generation.

PR highlights:
-Enforce order of columns and values when using SetMap by sorting key strings.
-Update TestInsertBuilderSetMap to test for multiple fields

Please let me know if this is a viable solution to this issue or any suggestions? Thank you.

