### PR TITLE
More closely follow conventions as applied by Go code linters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ users := sq.Select("*").From("users").Join("emails USING (email_id)")
 
 active := users.Where(sq.Eq{"deleted_at": nil})
 
-sql, args, err := active.ToSql()
+sql, args, err := active.ToSQL()
 
 sql == "SELECT * FROM users JOIN emails USING (email_id) WHERE deleted_at IS NULL"
 ```
@@ -39,7 +39,7 @@ sql == "SELECT * FROM users JOIN emails USING (email_id) WHERE deleted_at IS NUL
 sql, args, err := sq.
     Insert("users").Columns("name", "age").
     Values("moe", 13).Values("larry", sq.Expr("? + 5", 12)).
-    ToSql()
+    ToSQL()
 
 sql == "INSERT INTO users (name,age) VALUES (?,?),(?,? + 5)"
 ```

--- a/case.go
+++ b/case.go
@@ -19,15 +19,15 @@ type sqlizerBuffer struct {
 	err  error
 }
 
-// WriteSql converts Sqlizer to SQL strings and writes it to buffer
-func (b *sqlizerBuffer) WriteSql(item Sqlizer) {
+// WriteSQL converts Sqlizer to SQL strings and writes it to buffer
+func (b *sqlizerBuffer) WriteSQL(item Sqlizer) {
 	if b.err != nil {
 		return
 	}
 
 	var str string
 	var args []interface{}
-	str, args, b.err = item.ToSql()
+	str, args, b.err = item.ToSQL()
 
 	if b.err != nil {
 		return
@@ -38,7 +38,7 @@ func (b *sqlizerBuffer) WriteSql(item Sqlizer) {
 	b.args = append(b.args, args...)
 }
 
-func (b *sqlizerBuffer) ToSql() (string, []interface{}, error) {
+func (b *sqlizerBuffer) ToSQL() (string, []interface{}, error) {
 	return b.String(), b.args, b.err
 }
 
@@ -59,8 +59,8 @@ type caseData struct {
 	Else      Sqlizer
 }
 
-// ToSql implements Sqlizer
-func (d *caseData) ToSql() (sqlStr string, args []interface{}, err error) {
+// ToSQL implements Sqlizer
+func (d *caseData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	if len(d.WhenParts) == 0 {
 		err = errors.New("case expression must contain at lease one WHEN clause")
 
@@ -71,33 +71,33 @@ func (d *caseData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	sql.WriteString("CASE ")
 	if d.What != nil {
-		sql.WriteSql(d.What)
+		sql.WriteSQL(d.What)
 	}
 
 	for _, p := range d.WhenParts {
 		sql.WriteString("WHEN ")
-		sql.WriteSql(p.when)
+		sql.WriteSQL(p.when)
 		sql.WriteString("THEN ")
-		sql.WriteSql(p.then)
+		sql.WriteSQL(p.then)
 	}
 
 	if d.Else != nil {
 		sql.WriteString("ELSE ")
-		sql.WriteSql(d.Else)
+		sql.WriteSQL(d.Else)
 	}
 
 	sql.WriteString("END")
 
-	return sql.ToSql()
+	return sql.ToSQL()
 }
 
 // CaseBuilder builds SQL CASE construct which could be used as parts of queries.
 type CaseBuilder builder.Builder
 
-// ToSql builds the query into a SQL string and bound args.
-func (b CaseBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b CaseBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(caseData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 // what sets optional value for CASE construct "CASE [value] ..."
@@ -112,7 +112,7 @@ func (b CaseBuilder) When(when interface{}, then interface{}) CaseBuilder {
 	return builder.Append(b, "WhenParts", newWhenPart(when, then)).(CaseBuilder)
 }
 
-// What sets optional "ELSE ..." part for CASE construct
+// Else sets optional "ELSE ..." part for CASE construct
 func (b CaseBuilder) Else(expr interface{}) CaseBuilder {
 	return builder.Set(b, "Else", newPart(expr)).(CaseBuilder)
 }

--- a/case_test.go
+++ b/case_test.go
@@ -15,17 +15,17 @@ func TestCaseWithVal(t *testing.T) {
 	qb := Select().
 		Column(caseStmt).
 		From("table")
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
-	expectedSql := "SELECT CASE number " +
+	expectedSQL := "SELECT CASE number " +
 		"WHEN 1 THEN one " +
 		"WHEN 2 THEN two " +
 		"ELSE ? " +
 		"END " +
 		"FROM table"
-	assert.Equal(t, expectedSql, sql)
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{"big number"}
 	assert.Equal(t, expectedArgs, args)
@@ -38,15 +38,15 @@ func TestCaseWithComplexVal(t *testing.T) {
 	qb := Select().
 		Column(Alias(caseStmt, "complexCase")).
 		From("table")
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
-	expectedSql := "SELECT (CASE ? > ? " +
+	expectedSQL := "SELECT (CASE ? > ? " +
 		"WHEN true THEN 'T' " +
 		"END) AS complexCase " +
 		"FROM table"
-	assert.Equal(t, expectedSql, sql)
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{10, 5}
 	assert.Equal(t, expectedArgs, args)
@@ -58,17 +58,17 @@ func TestCaseWithNoVal(t *testing.T) {
 		When(Expr("x > ?", 1), Expr("CONCAT('x is greater than ', ?)", 2))
 
 	qb := Select().Column(caseStmt).From("table")
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
-	expectedSql := "SELECT CASE " +
+	expectedSQL := "SELECT CASE " +
 		"WHEN x = ? THEN x is zero " +
 		"WHEN x > ? THEN CONCAT('x is greater than ', ?) " +
 		"END " +
 		"FROM table"
 
-	assert.Equal(t, expectedSql, sql)
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{0, 1, 2}
 	assert.Equal(t, expectedArgs, args)
@@ -80,17 +80,17 @@ func TestCaseWithExpr(t *testing.T) {
 		Else("42")
 
 	qb := Select().Column(caseStmt).From("table")
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
-	expectedSql := "SELECT CASE x = ? " +
+	expectedSQL := "SELECT CASE x = ? " +
 		"WHEN true THEN ? " +
 		"ELSE 42 " +
 		"END " +
 		"FROM table"
 
-	assert.Equal(t, expectedSql, sql)
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{true, "it's true!"}
 	assert.Equal(t, expectedArgs, args)
@@ -109,16 +109,16 @@ func TestMultipleCase(t *testing.T) {
 		Column(Alias(caseStmtExpr, "case_expr")).
 		From("table")
 
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
-	expectedSql := "SELECT " +
+	expectedSQL := "SELECT " +
 		"(CASE x = ? WHEN true THEN ? ELSE 42 END) AS case_noval, " +
 		"(CASE WHEN x = ? THEN 'x is zero' WHEN x > ? THEN CONCAT('x is greater than ', ?) END) AS case_expr " +
 		"FROM table"
 
-	assert.Equal(t, expectedSql, sql)
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{
 		true, "it's true!",
@@ -133,7 +133,7 @@ func TestCaseWithNoWhenClause(t *testing.T) {
 
 	qb := Select().Column(caseStmt).From("table")
 
-	_, _, err := qb.ToSql()
+	_, _, err := qb.ToSQL()
 
 	assert.Error(t, err)
 

--- a/delete.go
+++ b/delete.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"github.com/lann/builder"
 	"strings"
+
+	"github.com/lann/builder"
 )
 
 type deleteData struct {
@@ -22,12 +23,12 @@ type deleteData struct {
 
 func (d *deleteData) Exec() (sql.Result, error) {
 	if d.RunWith == nil {
-		return nil, RunnerNotSet
+		return nil, ErrRunnerNotSet
 	}
 	return ExecWith(d.RunWith, d)
 }
 
-func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
+func (d *deleteData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	if len(d.From) == 0 {
 		err = fmt.Errorf("delete statements must specify a From table")
 		return
@@ -36,7 +37,7 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, _ = d.Prefixes.AppendToSQL(sql, " ", args)
 		sql.WriteString(" ")
 	}
 
@@ -45,7 +46,7 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.WhereParts) > 0 {
 		sql.WriteString(" WHERE ")
-		args, err = appendToSql(d.WhereParts, sql, " AND ", args)
+		args, err = appendToSQL(d.WhereParts, sql, " AND ", args)
 		if err != nil {
 			return
 		}
@@ -68,13 +69,12 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, _ = d.Suffixes.AppendToSQL(sql, " ", args)
 	}
 
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
 	return
 }
-
 
 // Builder
 
@@ -108,10 +108,10 @@ func (b DeleteBuilder) Exec() (sql.Result, error) {
 
 // SQL methods
 
-// ToSql builds the query into a SQL string and bound args.
-func (b DeleteBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b DeleteBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(deleteData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 // Prefix adds an expression to the beginning of the query

--- a/delete_test.go
+++ b/delete_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeleteBuilderToSql(t *testing.T) {
+func TestDeleteBuilderToSQL(t *testing.T) {
 	b := Delete("").
 		Prefix("WITH prefix AS ?", 0).
 		From("a").
@@ -16,31 +16,31 @@ func TestDeleteBuilderToSql(t *testing.T) {
 		Offset(3).
 		Suffix("RETURNING ?", 4)
 
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql :=
+	expectedSQL :=
 		"WITH prefix AS ? " +
 			"DELETE FROM a WHERE b = ? ORDER BY c LIMIT 2 OFFSET 3 " +
 			"RETURNING ?"
-	assert.Equal(t, expectedSql, sql)
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{0, 1, 4}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestDeleteBuilderToSqlErr(t *testing.T) {
-	_, _, err := Delete("").ToSql()
+func TestDeleteBuilderToSQLErr(t *testing.T) {
+	_, _, err := Delete("").ToSQL()
 	assert.Error(t, err)
 }
 
 func TestDeleteBuilderPlaceholders(t *testing.T) {
 	b := Delete("test").Where("x = ? AND y = ?", 1, 2)
 
-	sql, _, _ := b.PlaceholderFormat(Question).ToSql()
+	sql, _, _ := b.PlaceholderFormat(Question).ToSQL()
 	assert.Equal(t, "DELETE FROM test WHERE x = ? AND y = ?", sql)
 
-	sql, _, _ = b.PlaceholderFormat(Dollar).ToSql()
+	sql, _, _ = b.PlaceholderFormat(Dollar).ToSQL()
 	assert.Equal(t, "DELETE FROM test WHERE x = $1 AND y = $2", sql)
 }
 
@@ -48,10 +48,10 @@ func TestDeleteBuilderRunners(t *testing.T) {
 	db := &DBStub{}
 	b := Delete("test").Where("x = ?", 1).RunWith(db)
 
-	expectedSql := "DELETE FROM test WHERE x = ?"
+	expectedSQL := "DELETE FROM test WHERE x = ?"
 
 	b.Exec()
-	assert.Equal(t, expectedSql, db.LastExecSql)
+	assert.Equal(t, expectedSQL, db.LastExecSql)
 }
 
 func TestDeleteBuilderNoRunner(t *testing.T) {

--- a/delete_test.go
+++ b/delete_test.go
@@ -51,12 +51,12 @@ func TestDeleteBuilderRunners(t *testing.T) {
 	expectedSQL := "DELETE FROM test WHERE x = ?"
 
 	b.Exec()
-	assert.Equal(t, expectedSQL, db.LastExecSql)
+	assert.Equal(t, expectedSQL, db.LastExecSQL)
 }
 
 func TestDeleteBuilderNoRunner(t *testing.T) {
 	b := Delete("test")
 
 	_, err := b.Exec()
-	assert.Equal(t, RunnerNotSet, err)
+	assert.Equal(t, ErrRunnerNotSet, err)
 }

--- a/expr.go
+++ b/expr.go
@@ -85,8 +85,10 @@ func (eq Eq) toSQL(useNotOpr bool) (sql string, args []interface{}, err error) {
 		nullOpr = "IS NOT"
 	}
 
+	// Order the pairs.
+
 	for key, val := range eq {
-		expr := ""
+		var expr string
 
 		switch v := val.(type) {
 		case driver.Valuer:
@@ -155,8 +157,6 @@ func (lt Lt) toSQL(opposite, orEq bool) (sql string, args []interface{}, err err
 	}
 
 	for key, val := range lt {
-		expr := ""
-
 		switch v := val.(type) {
 		case driver.Valuer:
 			if val, err = v.Value(); err != nil {
@@ -175,7 +175,7 @@ func (lt Lt) toSQL(opposite, orEq bool) (sql string, args []interface{}, err err
 			return
 		}
 
-		expr = fmt.Sprintf("%s %s ?", key, opr)
+		expr := fmt.Sprintf("%s %s ?", key, opr)
 		args = append(args, val)
 		exprs = append(exprs, expr)
 	}

--- a/expr.go
+++ b/expr.go
@@ -85,8 +85,6 @@ func (eq Eq) toSQL(useNotOpr bool) (sql string, args []interface{}, err error) {
 		nullOpr = "IS NOT"
 	}
 
-	// Order the pairs.
-
 	for key, val := range eq {
 		var expr string
 

--- a/expr.go
+++ b/expr.go
@@ -21,13 +21,13 @@ func Expr(sql string, args ...interface{}) expr {
 	return expr{sql: sql, args: args}
 }
 
-func (e expr) ToSql() (sql string, args []interface{}, err error) {
+func (e expr) ToSQL() (sql string, args []interface{}, err error) {
 	return e.sql, e.args, nil
 }
 
 type exprs []expr
 
-func (es exprs) AppendToSql(w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
+func (es exprs) AppendToSQL(w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
 	for i, e := range es {
 		if i > 0 {
 			_, err := io.WriteString(w, sep)
@@ -58,8 +58,8 @@ func Alias(expr Sqlizer, alias string) aliasExpr {
 	return aliasExpr{expr, alias}
 }
 
-func (e aliasExpr) ToSql() (sql string, args []interface{}, err error) {
-	sql, args, err = e.expr.ToSql()
+func (e aliasExpr) ToSQL() (sql string, args []interface{}, err error) {
+	sql, args, err = e.expr.ToSQL()
 	if err == nil {
 		sql = fmt.Sprintf("(%s) AS %s", sql, e.alias)
 	}
@@ -71,12 +71,12 @@ func (e aliasExpr) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(Eq{"id": 1})
 type Eq map[string]interface{}
 
-func (eq Eq) toSql(useNotOpr bool) (sql string, args []interface{}, err error) {
+func (eq Eq) toSQL(useNotOpr bool) (sql string, args []interface{}, err error) {
 	var (
 		exprs    []string
-		equalOpr string = "="
-		inOpr    string = "IN"
-		nullOpr  string = "IS"
+		equalOpr = "="
+		inOpr    = "IN"
+		nullOpr  = "IS"
 	)
 
 	if useNotOpr {
@@ -122,8 +122,8 @@ func (eq Eq) toSql(useNotOpr bool) (sql string, args []interface{}, err error) {
 	return
 }
 
-func (eq Eq) ToSql() (sql string, args []interface{}, err error) {
-	return eq.toSql(false)
+func (eq Eq) ToSQL() (sql string, args []interface{}, err error) {
+	return eq.toSQL(false)
 }
 
 // NotEq is syntactic sugar for use with Where/Having/Set methods.
@@ -131,8 +131,8 @@ func (eq Eq) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(NotEq{"id": 1}) == "id <> 1"
 type NotEq Eq
 
-func (neq NotEq) ToSql() (sql string, args []interface{}, err error) {
-	return Eq(neq).toSql(true)
+func (neq NotEq) ToSQL() (sql string, args []interface{}, err error) {
+	return Eq(neq).toSQL(true)
 }
 
 // Lt is syntactic sugar for use with Where/Having/Set methods.
@@ -140,10 +140,10 @@ func (neq NotEq) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(Lt{"id": 1})
 type Lt map[string]interface{}
 
-func (lt Lt) toSql(opposite, orEq bool) (sql string, args []interface{}, err error) {
+func (lt Lt) toSQL(opposite, orEq bool) (sql string, args []interface{}, err error) {
 	var (
 		exprs []string
-		opr   string = "<"
+		opr   = "<"
 	)
 
 	if opposite {
@@ -167,24 +167,24 @@ func (lt Lt) toSql(opposite, orEq bool) (sql string, args []interface{}, err err
 		if val == nil {
 			err = fmt.Errorf("cannot use null with less than or greater than operators")
 			return
-		} else {
-			valVal := reflect.ValueOf(val)
-			if valVal.Kind() == reflect.Array || valVal.Kind() == reflect.Slice {
-				err = fmt.Errorf("cannot use array or slice with less than or greater than operators")
-				return
-			} else {
-				expr = fmt.Sprintf("%s %s ?", key, opr)
-				args = append(args, val)
-			}
 		}
+
+		valVal := reflect.ValueOf(val)
+		if valVal.Kind() == reflect.Array || valVal.Kind() == reflect.Slice {
+			err = fmt.Errorf("cannot use array or slice with less than or greater than operators")
+			return
+		}
+
+		expr = fmt.Sprintf("%s %s ?", key, opr)
+		args = append(args, val)
 		exprs = append(exprs, expr)
 	}
 	sql = strings.Join(exprs, " AND ")
 	return
 }
 
-func (lt Lt) ToSql() (sql string, args []interface{}, err error) {
-	return lt.toSql(false, false)
+func (lt Lt) ToSQL() (sql string, args []interface{}, err error) {
+	return lt.toSQL(false, false)
 }
 
 // LtOrEq is syntactic sugar for use with Where/Having/Set methods.
@@ -192,8 +192,8 @@ func (lt Lt) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(LtOrEq{"id": 1}) == "id <= 1"
 type LtOrEq Lt
 
-func (ltOrEq LtOrEq) ToSql() (sql string, args []interface{}, err error) {
-	return Lt(ltOrEq).toSql(false, true)
+func (ltOrEq LtOrEq) ToSQL() (sql string, args []interface{}, err error) {
+	return Lt(ltOrEq).toSQL(false, true)
 }
 
 // Gt is syntactic sugar for use with Where/Having/Set methods.
@@ -201,8 +201,8 @@ func (ltOrEq LtOrEq) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(Gt{"id": 1}) == "id > 1"
 type Gt Lt
 
-func (gt Gt) ToSql() (sql string, args []interface{}, err error) {
-	return Lt(gt).toSql(true, false)
+func (gt Gt) ToSQL() (sql string, args []interface{}, err error) {
+	return Lt(gt).toSQL(true, false)
 }
 
 // GtOrEq is syntactic sugar for use with Where/Having/Set methods.
@@ -210,8 +210,8 @@ func (gt Gt) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(GtOrEq{"id": 1}) == "id >= 1"
 type GtOrEq Lt
 
-func (gtOrEq GtOrEq) ToSql() (sql string, args []interface{}, err error) {
-	return Lt(gtOrEq).toSql(true, true)
+func (gtOrEq GtOrEq) ToSQL() (sql string, args []interface{}, err error) {
+	return Lt(gtOrEq).toSQL(true, true)
 }
 
 type conj []Sqlizer
@@ -219,12 +219,12 @@ type conj []Sqlizer
 func (c conj) join(sep string) (sql string, args []interface{}, err error) {
 	var sqlParts []string
 	for _, sqlizer := range c {
-		partSql, partArgs, err := sqlizer.ToSql()
+		partSQL, partArgs, err := sqlizer.ToSQL()
 		if err != nil {
 			return "", nil, err
 		}
-		if partSql != "" {
-			sqlParts = append(sqlParts, partSql)
+		if partSQL != "" {
+			sqlParts = append(sqlParts, partSQL)
 			args = append(args, partArgs...)
 		}
 	}
@@ -236,12 +236,12 @@ func (c conj) join(sep string) (sql string, args []interface{}, err error) {
 
 type And conj
 
-func (a And) ToSql() (string, []interface{}, error) {
+func (a And) ToSQL() (string, []interface{}, error) {
 	return conj(a).join(" AND ")
 }
 
 type Or conj
 
-func (o Or) ToSql() (string, []interface{}, error) {
+func (o Or) ToSQL() (string, []interface{}, error) {
 	return conj(o).join(" OR ")
 }

--- a/expr_test.go
+++ b/expr_test.go
@@ -2,135 +2,136 @@ package squirrel
 
 import (
 	"database/sql"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestEqToSql(t *testing.T) {
+func TestEqToSQL(t *testing.T) {
 	b := Eq{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "id = ?"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "id = ?"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{1}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestEqInToSql(t *testing.T) {
+func TestEqInToSQL(t *testing.T) {
 	b := Eq{"id": []int{1, 2, 3}}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "id IN (?,?,?)"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "id IN (?,?,?)"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{1, 2, 3}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestNotEqToSql(t *testing.T) {
+func TestNotEqToSQL(t *testing.T) {
 	b := NotEq{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "id <> ?"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "id <> ?"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{1}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestEqNotInToSql(t *testing.T) {
+func TestEqNotInToSQL(t *testing.T) {
 	b := NotEq{"id": []int{1, 2, 3}}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "id NOT IN (?,?,?)"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "id NOT IN (?,?,?)"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{1, 2, 3}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestEqInEmptyToSql(t *testing.T) {
+func TestEqInEmptyToSQL(t *testing.T) {
 	b := Eq{"id": []int{}}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "id IN (NULL)"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "id IN (NULL)"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestLtToSql(t *testing.T) {
+func TestLtToSQL(t *testing.T) {
 	b := Lt{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "id < ?"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "id < ?"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{1}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestLtOrEqToSql(t *testing.T) {
+func TestLtOrEqToSQL(t *testing.T) {
 	b := LtOrEq{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "id <= ?"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "id <= ?"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{1}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestGtToSql(t *testing.T) {
+func TestGtToSQL(t *testing.T) {
 	b := Gt{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "id > ?"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "id > ?"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{1}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestGtOrEqToSql(t *testing.T) {
+func TestGtOrEqToSQL(t *testing.T) {
 	b := GtOrEq{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "id >= ?"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "id >= ?"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{1}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestExprNilToSql(t *testing.T) {
+func TestExprNilToSQL(t *testing.T) {
 	var b Sqlizer
 	b = NotEq{"name": nil}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 
-	expectedSql := "name IS NOT NULL"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "name IS NOT NULL"
+	assert.Equal(t, expectedSQL, sql)
 
 	b = Eq{"name": nil}
-	sql, args, err = b.ToSql()
+	sql, args, err = b.ToSQL()
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 
-	expectedSql = "name IS NULL"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL = "name IS NULL"
+	assert.Equal(t, expectedSQL, sql)
 }
 
 func TestNullTypeString(t *testing.T) {
@@ -138,7 +139,7 @@ func TestNullTypeString(t *testing.T) {
 	var name sql.NullString
 
 	b = Eq{"name": name}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Empty(t, args)
@@ -146,7 +147,7 @@ func TestNullTypeString(t *testing.T) {
 
 	name.Scan("Name")
 	b = Eq{"name": name}
-	sql, args, err = b.ToSql()
+	sql, args, err = b.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{"Name"}, args)
@@ -157,7 +158,7 @@ func TestNullTypeInt64(t *testing.T) {
 	var userID sql.NullInt64
 	userID.Scan(nil)
 	b := Eq{"user_id": userID}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Empty(t, args)
@@ -165,7 +166,7 @@ func TestNullTypeInt64(t *testing.T) {
 
 	userID.Scan(int64(10))
 	b = Eq{"user_id": userID}
-	sql, args, err = b.ToSql()
+	sql, args, err = b.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{int64(10)}, args)

--- a/insert.go
+++ b/insert.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"github.com/lann/builder"
 	"strings"
+
+	"github.com/lann/builder"
 )
 
 type insertData struct {
@@ -21,30 +22,30 @@ type insertData struct {
 
 func (d *insertData) Exec() (sql.Result, error) {
 	if d.RunWith == nil {
-		return nil, RunnerNotSet
+		return nil, ErrRunnerNotSet
 	}
 	return ExecWith(d.RunWith, d)
 }
 
 func (d *insertData) Query() (*sql.Rows, error) {
 	if d.RunWith == nil {
-		return nil, RunnerNotSet
+		return nil, ErrRunnerNotSet
 	}
 	return QueryWith(d.RunWith, d)
 }
 
 func (d *insertData) QueryRow() RowScanner {
 	if d.RunWith == nil {
-		return &Row{err: RunnerNotSet}
+		return &Row{err: ErrRunnerNotSet}
 	}
 	queryRower, ok := d.RunWith.(QueryRower)
 	if !ok {
-		return &Row{err: RunnerNotQueryRunner}
+		return &Row{err: ErrRunnerNotQueryRunner}
 	}
 	return QueryRowWith(queryRower, d)
 }
 
-func (d *insertData) ToSql() (sqlStr string, args []interface{}, err error) {
+func (d *insertData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	if len(d.Into) == 0 {
 		err = fmt.Errorf("insert statements must specify a table")
 		return
@@ -57,7 +58,7 @@ func (d *insertData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, _ = d.Prefixes.AppendToSQL(sql, " ", args)
 		sql.WriteString(" ")
 	}
 
@@ -99,7 +100,7 @@ func (d *insertData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, _ = d.Suffixes.AppendToSQL(sql, " ", args)
 	}
 
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
@@ -155,10 +156,10 @@ func (b InsertBuilder) Scan(dest ...interface{}) error {
 
 // SQL methods
 
-// ToSql builds the query into a SQL string and bound args.
-func (b InsertBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b InsertBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(insertData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 // Prefix adds an expression to the beginning of the query

--- a/insert_test.go
+++ b/insert_test.go
@@ -54,14 +54,14 @@ func TestInsertBuilderRunners(t *testing.T) {
 	expectedSQL := "INSERT INTO test VALUES (?)"
 
 	b.Exec()
-	assert.Equal(t, expectedSQL, db.LastExecSql)
+	assert.Equal(t, expectedSQL, db.LastExecSQL)
 }
 
 func TestInsertBuilderNoRunner(t *testing.T) {
 	b := Insert("test").Values(1)
 
 	_, err := b.Exec()
-	assert.Equal(t, RunnerNotSet, err)
+	assert.Equal(t, ErrRunnerNotSet, err)
 }
 
 func TestInsertBuilderSetMap(t *testing.T) {

--- a/insert_test.go
+++ b/insert_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInsertBuilderToSql(t *testing.T) {
+func TestInsertBuilderToSQL(t *testing.T) {
 	b := Insert("").
 		Prefix("WITH prefix AS ?", 0).
 		Into("a").
@@ -16,34 +16,34 @@ func TestInsertBuilderToSql(t *testing.T) {
 		Values(3, Expr("? + 1", 4)).
 		Suffix("RETURNING ?", 5)
 
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql :=
+	expectedSQL :=
 		"WITH prefix AS ? " +
 			"INSERT DELAYED IGNORE INTO a (b,c) VALUES (?,?),(?,? + 1) " +
 			"RETURNING ?"
-	assert.Equal(t, expectedSql, sql)
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{0, 1, 2, 3, 4, 5}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestInsertBuilderToSqlErr(t *testing.T) {
-	_, _, err := Insert("").Values(1).ToSql()
+func TestInsertBuilderToSQLErr(t *testing.T) {
+	_, _, err := Insert("").Values(1).ToSQL()
 	assert.Error(t, err)
 
-	_, _, err = Insert("x").ToSql()
+	_, _, err = Insert("x").ToSQL()
 	assert.Error(t, err)
 }
 
 func TestInsertBuilderPlaceholders(t *testing.T) {
 	b := Insert("test").Values(1, 2)
 
-	sql, _, _ := b.PlaceholderFormat(Question).ToSql()
+	sql, _, _ := b.PlaceholderFormat(Question).ToSQL()
 	assert.Equal(t, "INSERT INTO test VALUES (?,?)", sql)
 
-	sql, _, _ = b.PlaceholderFormat(Dollar).ToSql()
+	sql, _, _ = b.PlaceholderFormat(Dollar).ToSQL()
 	assert.Equal(t, "INSERT INTO test VALUES ($1,$2)", sql)
 }
 
@@ -51,10 +51,10 @@ func TestInsertBuilderRunners(t *testing.T) {
 	db := &DBStub{}
 	b := Insert("test").Values(1).RunWith(db)
 
-	expectedSql := "INSERT INTO test VALUES (?)"
+	expectedSQL := "INSERT INTO test VALUES (?)"
 
 	b.Exec()
-	assert.Equal(t, expectedSql, db.LastExecSql)
+	assert.Equal(t, expectedSQL, db.LastExecSql)
 }
 
 func TestInsertBuilderNoRunner(t *testing.T) {
@@ -67,11 +67,11 @@ func TestInsertBuilderNoRunner(t *testing.T) {
 func TestInsertBuilderSetMap(t *testing.T) {
 	b := Insert("table").SetMap(Eq{"field1": 1})
 
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql := "INSERT INTO table (field1) VALUES (?)"
-	assert.Equal(t, expectedSql, sql)
+	expectedSQL := "INSERT INTO table (field1) VALUES (?)"
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{1}
 	assert.Equal(t, expectedArgs, args)

--- a/part.go
+++ b/part.go
@@ -14,12 +14,12 @@ func newPart(pred interface{}, args ...interface{}) Sqlizer {
 	return &part{pred, args}
 }
 
-func (p part) ToSql() (sql string, args []interface{}, err error) {
+func (p part) ToSQL() (sql string, args []interface{}, err error) {
 	switch pred := p.pred.(type) {
 	case nil:
 		// no-op
 	case Sqlizer:
-		sql, args, err = pred.ToSql()
+		sql, args, err = pred.ToSQL()
 	case string:
 		sql = pred
 		args = p.args
@@ -29,12 +29,12 @@ func (p part) ToSql() (sql string, args []interface{}, err error) {
 	return
 }
 
-func appendToSql(parts []Sqlizer, w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
+func appendToSQL(parts []Sqlizer, w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
 	for i, p := range parts {
-		partSql, partArgs, err := p.ToSql()
+		partSQL, partArgs, err := p.ToSQL()
 		if err != nil {
 			return nil, err
-		} else if len(partSql) == 0 {
+		} else if len(partSQL) == 0 {
 			continue
 		}
 
@@ -45,7 +45,7 @@ func appendToSql(parts []Sqlizer, w io.Writer, sep string, args []interface{}) (
 			}
 		}
 
-		_, err = io.WriteString(w, partSql)
+		_, err = io.WriteString(w, partSQL)
 		if err != nil {
 			return nil, err
 		}

--- a/part.go
+++ b/part.go
@@ -39,7 +39,7 @@ func appendToSQL(parts []Sqlizer, w io.Writer, sep string, args []interface{}) (
 		}
 
 		if i > 0 {
-			_, err := io.WriteString(w, sep)
+			_, err = io.WriteString(w, sep)
 			if err != nil {
 				return nil, err
 			}

--- a/placeholder.go
+++ b/placeholder.go
@@ -42,21 +42,31 @@ func (_ dollarFormat) ReplacePlaceholders(sql string) (string, error) {
 		}
 
 		if len(sql[p:]) > 1 && sql[p:p+2] == "??" { // escape ?? => ?
-			buf.WriteString(sql[:p])
-			buf.WriteString("?")
+			if _, err := buf.WriteString(sql[:p]); err != nil {
+				return "", err
+			}
+			if _, err := buf.WriteString("?"); err != nil {
+				return "", err
+			}
 			if len(sql[p:]) == 1 {
 				break
 			}
 			sql = sql[p+2:]
 		} else {
 			i++
-			buf.WriteString(sql[:p])
-			fmt.Fprintf(buf, "$%d", i)
+			if _, err := buf.WriteString(sql[:p]); err != nil {
+				return "", err
+			}
+			if _, err := fmt.Fprintf(buf, "$%d", i); err != nil {
+				return "", err
+			}
 			sql = sql[p+1:]
 		}
 	}
 
-	buf.WriteString(sql)
+	if _, err := buf.WriteString(sql); err != nil {
+		return "", err
+	}
 	return buf.String(), nil
 }
 

--- a/select.go
+++ b/select.go
@@ -28,30 +28,30 @@ type selectData struct {
 
 func (d *selectData) Exec() (sql.Result, error) {
 	if d.RunWith == nil {
-		return nil, RunnerNotSet
+		return nil, ErrRunnerNotSet
 	}
 	return ExecWith(d.RunWith, d)
 }
 
 func (d *selectData) Query() (*sql.Rows, error) {
 	if d.RunWith == nil {
-		return nil, RunnerNotSet
+		return nil, ErrRunnerNotSet
 	}
 	return QueryWith(d.RunWith, d)
 }
 
 func (d *selectData) QueryRow() RowScanner {
 	if d.RunWith == nil {
-		return &Row{err: RunnerNotSet}
+		return &Row{err: ErrRunnerNotSet}
 	}
 	queryRower, ok := d.RunWith.(QueryRower)
 	if !ok {
-		return &Row{err: RunnerNotQueryRunner}
+		return &Row{err: ErrRunnerNotQueryRunner}
 	}
 	return QueryRowWith(queryRower, d)
 }
 
-func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
+func (d *selectData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	if len(d.Columns) == 0 {
 		err = fmt.Errorf("select statements must have at least one result column")
 		return
@@ -60,7 +60,7 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, _ = d.Prefixes.AppendToSQL(sql, " ", args)
 		sql.WriteString(" ")
 	}
 
@@ -72,7 +72,7 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 	}
 
 	if len(d.Columns) > 0 {
-		args, err = appendToSql(d.Columns, sql, ", ", args)
+		args, err = appendToSQL(d.Columns, sql, ", ", args)
 		if err != nil {
 			return
 		}
@@ -80,7 +80,7 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if d.From != nil {
 		sql.WriteString(" FROM ")
-		args, err = appendToSql([]Sqlizer{d.From}, sql, "", args)
+		args, err = appendToSQL([]Sqlizer{d.From}, sql, "", args)
 		if err != nil {
 			return
 		}
@@ -88,7 +88,7 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Joins) > 0 {
 		sql.WriteString(" ")
-		args, err = appendToSql(d.Joins, sql, " ", args)
+		args, err = appendToSQL(d.Joins, sql, " ", args)
 		if err != nil {
 			return
 		}
@@ -96,7 +96,7 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.WhereParts) > 0 {
 		sql.WriteString(" WHERE ")
-		args, err = appendToSql(d.WhereParts, sql, " AND ", args)
+		args, err = appendToSQL(d.WhereParts, sql, " AND ", args)
 		if err != nil {
 			return
 		}
@@ -109,7 +109,7 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.HavingParts) > 0 {
 		sql.WriteString(" HAVING ")
-		args, err = appendToSql(d.HavingParts, sql, " AND ", args)
+		args, err = appendToSQL(d.HavingParts, sql, " AND ", args)
 		if err != nil {
 			return
 		}
@@ -132,7 +132,7 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, _ = d.Suffixes.AppendToSQL(sql, " ", args)
 	}
 
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
@@ -188,10 +188,10 @@ func (b SelectBuilder) Scan(dest ...interface{}) error {
 
 // SQL methods
 
-// ToSql builds the query into a SQL string and bound args.
-func (b SelectBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b SelectBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(selectData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 // Prefix adds an expression to the beginning of the query

--- a/select_test.go
+++ b/select_test.go
@@ -87,13 +87,13 @@ func TestSelectBuilderRunners(t *testing.T) {
 	expectedSQL := "SELECT test"
 
 	b.Exec()
-	assert.Equal(t, expectedSQL, db.LastExecSql)
+	assert.Equal(t, expectedSQL, db.LastExecSQL)
 
 	b.Query()
-	assert.Equal(t, expectedSQL, db.LastQuerySql)
+	assert.Equal(t, expectedSQL, db.LastQuerySQL)
 
 	b.QueryRow()
-	assert.Equal(t, expectedSQL, db.LastQueryRowSql)
+	assert.Equal(t, expectedSQL, db.LastQueryRowSQL)
 
 	err := b.Scan()
 	assert.NoError(t, err)
@@ -103,13 +103,13 @@ func TestSelectBuilderNoRunner(t *testing.T) {
 	b := Select("test")
 
 	_, err := b.Exec()
-	assert.Equal(t, RunnerNotSet, err)
+	assert.Equal(t, ErrRunnerNotSet, err)
 
 	_, err = b.Query()
-	assert.Equal(t, RunnerNotSet, err)
+	assert.Equal(t, ErrRunnerNotSet, err)
 
 	err = b.Scan()
-	assert.Equal(t, RunnerNotSet, err)
+	assert.Equal(t, ErrRunnerNotSet, err)
 }
 
 func TestSelectBuilderSimpleJoin(t *testing.T) {

--- a/squirrel.go
+++ b/squirrel.go
@@ -12,12 +12,12 @@ import (
 	"github.com/lann/builder"
 )
 
-// Sqlizer is the interface that wraps the ToSql method.
+// Sqlizer is the interface that wraps the ToSQL method.
 //
-// ToSql returns a SQL representation of the Sqlizer, along with a slice of args
+// ToSQL returns a SQL representation of the Sqlizer, along with a slice of args
 // as passed to e.g. database/sql.Exec. It can also return an error.
 type Sqlizer interface {
-	ToSql() (string, []interface{}, error)
+	ToSQL() (string, []interface{}, error)
 }
 
 // Execer is the interface that wraps the Exec method.
@@ -84,15 +84,15 @@ func setRunWith(b interface{}, baseRunner BaseRunner) interface{} {
 	return builder.Set(b, "RunWith", runner)
 }
 
-// RunnerNotSet is returned by methods that need a Runner if it isn't set.
-var RunnerNotSet = fmt.Errorf("cannot run; no Runner set (RunWith)")
+// ErrRunnerNotSet is returned by methods that need a Runner if it isn't set.
+var ErrRunnerNotSet = fmt.Errorf("cannot run; no Runner set (RunWith)")
 
-// RunnerNotQueryRunner is returned by QueryRow if the RunWith value doesn't implement QueryRower.
-var RunnerNotQueryRunner = fmt.Errorf("cannot QueryRow; Runner is not a QueryRower")
+// ErrRunnerNotQueryRunner is returned by QueryRow if the RunWith value doesn't implement QueryRower.
+var ErrRunnerNotQueryRunner = fmt.Errorf("cannot QueryRow; Runner is not a QueryRower")
 
 // ExecWith Execs the SQL returned by s with db.
 func ExecWith(db Execer, s Sqlizer) (res sql.Result, err error) {
-	query, args, err := s.ToSql()
+	query, args, err := s.ToSQL()
 	if err != nil {
 		return
 	}
@@ -101,7 +101,7 @@ func ExecWith(db Execer, s Sqlizer) (res sql.Result, err error) {
 
 // QueryWith Querys the SQL returned by s with db.
 func QueryWith(db Queryer, s Sqlizer) (rows *sql.Rows, err error) {
-	query, args, err := s.ToSql()
+	query, args, err := s.ToSQL()
 	if err != nil {
 		return
 	}
@@ -110,23 +110,23 @@ func QueryWith(db Queryer, s Sqlizer) (rows *sql.Rows, err error) {
 
 // QueryRowWith QueryRows the SQL returned by s with db.
 func QueryRowWith(db QueryRower, s Sqlizer) RowScanner {
-	query, args, err := s.ToSql()
+	query, args, err := s.ToSQL()
 	return &Row{RowScanner: db.QueryRow(query, args...), err: err}
 }
 
-// DebugSqlizer calls ToSql on s and shows the approximate SQL to be executed
+// DebugSqlizer calls ToSQL on s and shows the approximate SQL to be executed
 //
-// If ToSql returns an error, the result of this method will look like:
-// "[ToSql error: %s]" or "[DebugSqlizer error: %s]"
+// If ToSQL returns an error, the result of this method will look like:
+// "[ToSQL error: %s]" or "[DebugSqlizer error: %s]"
 //
 // IMPORTANT: As its name suggests, this function should only be used for
 // debugging. While the string result *might* be valid SQL, this function does
 // not try very hard to ensure it. Additionally, executing the output of this
 // function with any untrusted user input is certainly insecure.
 func DebugSqlizer(s Sqlizer) string {
-	sql, args, err := s.ToSql()
+	sql, args, err := s.ToSQL()
 	if err != nil {
-		return fmt.Sprintf("[ToSql error: %s]", err)
+		return fmt.Sprintf("[ToSQL error: %s]", err)
 	}
 
 	// TODO: dedupe this with placeholder.go

--- a/squirrel_test.go
+++ b/squirrel_test.go
@@ -12,41 +12,41 @@ import (
 type DBStub struct {
 	err error
 
-	LastPrepareSql string
+	LastPrepareSQL string
 	PrepareCount   int
 
-	LastExecSql  string
+	LastExecSQL  string
 	LastExecArgs []interface{}
 
-	LastQuerySql  string
+	LastQuerySQL  string
 	LastQueryArgs []interface{}
 
-	LastQueryRowSql  string
+	LastQueryRowSQL  string
 	LastQueryRowArgs []interface{}
 }
 
-var StubError = fmt.Errorf("this is a stub; this is only a stub")
+var ErrStubError = fmt.Errorf("this is a stub; this is only a stub")
 
 func (s *DBStub) Prepare(query string) (*sql.Stmt, error) {
-	s.LastPrepareSql = query
+	s.LastPrepareSQL = query
 	s.PrepareCount++
 	return nil, nil
 }
 
 func (s *DBStub) Exec(query string, args ...interface{}) (sql.Result, error) {
-	s.LastExecSql = query
+	s.LastExecSQL = query
 	s.LastExecArgs = args
 	return nil, nil
 }
 
 func (s *DBStub) Query(query string, args ...interface{}) (*sql.Rows, error) {
-	s.LastQuerySql = query
+	s.LastQuerySQL = query
 	s.LastQueryArgs = args
 	return nil, nil
 }
 
 func (s *DBStub) QueryRow(query string, args ...interface{}) RowScanner {
-	s.LastQueryRowSql = query
+	s.LastQueryRowSQL = query
 	s.LastQueryRowArgs = args
 	return &Row{RowScanner: &RowStub{}}
 }
@@ -57,22 +57,22 @@ var sqlStr = "SELECT test"
 func TestExecWith(t *testing.T) {
 	db := &DBStub{}
 	ExecWith(db, sqlizer)
-	assert.Equal(t, sqlStr, db.LastExecSql)
+	assert.Equal(t, sqlStr, db.LastExecSQL)
 }
 
 func TestQueryWith(t *testing.T) {
 	db := &DBStub{}
 	QueryWith(db, sqlizer)
-	assert.Equal(t, sqlStr, db.LastQuerySql)
+	assert.Equal(t, sqlStr, db.LastQuerySQL)
 }
 
 func TestQueryRowWith(t *testing.T) {
 	db := &DBStub{}
 	QueryRowWith(db, sqlizer)
-	assert.Equal(t, sqlStr, db.LastQueryRowSql)
+	assert.Equal(t, sqlStr, db.LastQueryRowSQL)
 }
 
-func TestWithToSqlErr(t *testing.T) {
+func TestWithToSQLErr(t *testing.T) {
 	db := &DBStub{}
 	sqlizer := Select()
 
@@ -100,5 +100,5 @@ func TestDebugSqlizerErrors(t *testing.T) {
 	assert.True(t, strings.HasPrefix(errorMsg, "[DebugSqlizer error: "))
 
 	errorMsg = DebugSqlizer(Lt{"x": nil}) // Cannot use nil values with Lt
-	assert.True(t, strings.HasPrefix(errorMsg, "[ToSql error: "))
+	assert.True(t, strings.HasPrefix(errorMsg, "[ToSQL error: "))
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -13,7 +13,7 @@ func TestStatementBuilder(t *testing.T) {
 	sb := StatementBuilder.RunWith(db)
 
 	sb.Select("test").Exec()
-	assert.Equal(t, "SELECT test", db.LastExecSql)
+	assert.Equal(t, "SELECT test", db.LastExecSQL)
 }
 
 func TestStatementBuilderPlaceholderFormat(t *testing.T) {
@@ -21,7 +21,7 @@ func TestStatementBuilderPlaceholderFormat(t *testing.T) {
 	sb := StatementBuilder.RunWith(db).PlaceholderFormat(Dollar)
 
 	sb.Select("test").Where("x = ?").Exec()
-	assert.Equal(t, "SELECT test WHERE x = $1", db.LastExecSql)
+	assert.Equal(t, "SELECT test WHERE x = $1", db.LastExecSQL)
 }
 
 func TestRunWithDB(t *testing.T) {

--- a/stmtcacher_test.go
+++ b/stmtcacher_test.go
@@ -12,7 +12,7 @@ func TestStmtCacherPrepare(t *testing.T) {
 	query := "SELECT 1"
 
 	sc.Prepare(query)
-	assert.Equal(t, query, db.LastPrepareSql)
+	assert.Equal(t, query, db.LastPrepareSQL)
 
 	sc.Prepare(query)
 	assert.Equal(t, 1, db.PrepareCount, "expected 1 Prepare, got %d", db.PrepareCount)

--- a/update.go
+++ b/update.go
@@ -198,7 +198,7 @@ func (b UpdateBuilder) SetMap(clauses map[string]interface{}) UpdateBuilder {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		val, _ := clauses[key]
+		val := clauses[key]
 		b = b.Set(key, val)
 	}
 	return b

--- a/update.go
+++ b/update.go
@@ -30,30 +30,30 @@ type setClause struct {
 
 func (d *updateData) Exec() (sql.Result, error) {
 	if d.RunWith == nil {
-		return nil, RunnerNotSet
+		return nil, ErrRunnerNotSet
 	}
 	return ExecWith(d.RunWith, d)
 }
 
 func (d *updateData) Query() (*sql.Rows, error) {
 	if d.RunWith == nil {
-		return nil, RunnerNotSet
+		return nil, ErrRunnerNotSet
 	}
 	return QueryWith(d.RunWith, d)
 }
 
 func (d *updateData) QueryRow() RowScanner {
 	if d.RunWith == nil {
-		return &Row{err: RunnerNotSet}
+		return &Row{err: ErrRunnerNotSet}
 	}
 	queryRower, ok := d.RunWith.(QueryRower)
 	if !ok {
-		return &Row{err: RunnerNotQueryRunner}
+		return &Row{err: ErrRunnerNotQueryRunner}
 	}
 	return QueryRowWith(queryRower, d)
 }
 
-func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
+func (d *updateData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	if len(d.Table) == 0 {
 		err = fmt.Errorf("update statements must specify a table")
 		return
@@ -66,7 +66,7 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, _ = d.Prefixes.AppendToSQL(sql, " ", args)
 		sql.WriteString(" ")
 	}
 
@@ -76,22 +76,22 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql.WriteString(" SET ")
 	setSqls := make([]string, len(d.SetClauses))
 	for i, setClause := range d.SetClauses {
-		var valSql string
+		var valSQL string
 		e, isExpr := setClause.value.(expr)
 		if isExpr {
-			valSql = e.sql
+			valSQL = e.sql
 			args = append(args, e.args...)
 		} else {
-			valSql = "?"
+			valSQL = "?"
 			args = append(args, setClause.value)
 		}
-		setSqls[i] = fmt.Sprintf("%s = %s", setClause.column, valSql)
+		setSqls[i] = fmt.Sprintf("%s = %s", setClause.column, valSQL)
 	}
 	sql.WriteString(strings.Join(setSqls, ", "))
 
 	if len(d.WhereParts) > 0 {
 		sql.WriteString(" WHERE ")
-		args, err = appendToSql(d.WhereParts, sql, " AND ", args)
+		args, err = appendToSQL(d.WhereParts, sql, " AND ", args)
 		if err != nil {
 			return
 		}
@@ -114,7 +114,7 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, _ = d.Suffixes.AppendToSQL(sql, " ", args)
 	}
 
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
@@ -167,10 +167,10 @@ func (b UpdateBuilder) Scan(dest ...interface{}) error {
 
 // SQL methods
 
-// ToSql builds the query into a SQL string and bound args.
-func (b UpdateBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b UpdateBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(updateData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 // Prefix adds an expression to the beginning of the query

--- a/update_test.go
+++ b/update_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpdateBuilderToSql(t *testing.T) {
+func TestUpdateBuilderToSQL(t *testing.T) {
 	b := Update("").
 		Prefix("WITH prefix AS ?", 0).
 		Table("a").
@@ -18,35 +18,35 @@ func TestUpdateBuilderToSql(t *testing.T) {
 		Offset(5).
 		Suffix("RETURNING ?", 6)
 
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
-	expectedSql :=
+	expectedSQL :=
 		"WITH prefix AS ? " +
 			"UPDATE a SET b = ? + 1, c = ? WHERE d = ? " +
 			"ORDER BY e LIMIT 4 OFFSET 5 " +
 			"RETURNING ?"
-	assert.Equal(t, expectedSql, sql)
+	assert.Equal(t, expectedSQL, sql)
 
 	expectedArgs := []interface{}{0, 1, 2, 3, 6}
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestUpdateBuilderToSqlErr(t *testing.T) {
-	_, _, err := Update("").Set("x", 1).ToSql()
+func TestUpdateBuilderToSQLErr(t *testing.T) {
+	_, _, err := Update("").Set("x", 1).ToSQL()
 	assert.Error(t, err)
 
-	_, _, err = Update("x").ToSql()
+	_, _, err = Update("x").ToSQL()
 	assert.Error(t, err)
 }
 
 func TestUpdateBuilderPlaceholders(t *testing.T) {
 	b := Update("test").SetMap(Eq{"x": 1, "y": 2})
 
-	sql, _, _ := b.PlaceholderFormat(Question).ToSql()
+	sql, _, _ := b.PlaceholderFormat(Question).ToSQL()
 	assert.Equal(t, "UPDATE test SET x = ?, y = ?", sql)
 
-	sql, _, _ = b.PlaceholderFormat(Dollar).ToSql()
+	sql, _, _ = b.PlaceholderFormat(Dollar).ToSQL()
 	assert.Equal(t, "UPDATE test SET x = $1, y = $2", sql)
 }
 
@@ -54,10 +54,10 @@ func TestUpdateBuilderRunners(t *testing.T) {
 	db := &DBStub{}
 	b := Update("test").Set("x", 1).RunWith(db)
 
-	expectedSql := "UPDATE test SET x = ?"
+	expectedSQL := "UPDATE test SET x = ?"
 
 	b.Exec()
-	assert.Equal(t, expectedSql, db.LastExecSql)
+	assert.Equal(t, expectedSQL, db.LastExecSQL)
 }
 
 func TestUpdateBuilderNoRunner(t *testing.T) {

--- a/update_test.go
+++ b/update_test.go
@@ -64,5 +64,5 @@ func TestUpdateBuilderNoRunner(t *testing.T) {
 	b := Update("test").Set("x", 1)
 
 	_, err := b.Exec()
-	assert.Equal(t, RunnerNotSet, err)
+	assert.Equal(t, ErrRunnerNotSet, err)
 }

--- a/where.go
+++ b/where.go
@@ -10,14 +10,14 @@ func newWherePart(pred interface{}, args ...interface{}) Sqlizer {
 	return &wherePart{pred: pred, args: args}
 }
 
-func (p wherePart) ToSql() (sql string, args []interface{}, err error) {
+func (p wherePart) ToSQL() (sql string, args []interface{}, err error) {
 	switch pred := p.pred.(type) {
 	case nil:
 		// no-op
 	case Sqlizer:
-		return pred.ToSql()
+		return pred.ToSQL()
 	case map[string]interface{}:
-		return Eq(pred).ToSql()
+		return Eq(pred).ToSQL()
 	case string:
 		sql = pred
 		args = p.args

--- a/where_test.go
+++ b/where_test.go
@@ -8,43 +8,43 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWherePartsAppendToSql(t *testing.T) {
+func TestWherePartsAppendToSQL(t *testing.T) {
 	parts := []Sqlizer{
 		newWherePart("x = ?", 1),
 		newWherePart(nil),
 		newWherePart(Eq{"y": 2}),
 	}
 	sql := &bytes.Buffer{}
-	args, _ := appendToSql(parts, sql, " AND ", []interface{}{})
+	args, _ := appendToSQL(parts, sql, " AND ", []interface{}{})
 	assert.Equal(t, "x = ? AND y = ?", sql.String())
 	assert.Equal(t, []interface{}{1, 2}, args)
 }
 
-func TestWherePartsAppendToSqlErr(t *testing.T) {
+func TestWherePartsAppendToSQLErr(t *testing.T) {
 	parts := []Sqlizer{newWherePart(1)}
-	_, err := appendToSql(parts, &bytes.Buffer{}, "", []interface{}{})
+	_, err := appendToSQL(parts, &bytes.Buffer{}, "", []interface{}{})
 	assert.Error(t, err)
 }
 
 func TestWherePartNil(t *testing.T) {
-	sql, _, _ := newWherePart(nil).ToSql()
+	sql, _, _ := newWherePart(nil).ToSQL()
 	assert.Equal(t, "", sql)
 }
 
 func TestWherePartErr(t *testing.T) {
-	_, _, err := newWherePart(1).ToSql()
+	_, _, err := newWherePart(1).ToSQL()
 	assert.Error(t, err)
 }
 
 func TestWherePartString(t *testing.T) {
-	sql, args, _ := newWherePart("x = ?", 1).ToSql()
+	sql, args, _ := newWherePart("x = ?", 1).ToSQL()
 	assert.Equal(t, "x = ?", sql)
 	assert.Equal(t, []interface{}{1}, args)
 }
 
 func TestWherePartMap(t *testing.T) {
 	test := func(pred interface{}) {
-		sql, _, _ := newWherePart(pred).ToSql()
+		sql, _, _ := newWherePart(pred).ToSQL()
 		expect := []string{"x = ? AND y = ?", "y = ? AND x = ?"}
 		if sql != expect[0] && sql != expect[1] {
 			t.Errorf("expected one of %#v, got %#v", expect, sql)


### PR DESCRIPTION
This PR contains a slew of changes recommended by the following linters (bundled by the [gometalinter](https://github.com/alecthomas/gometalinter) package.):
- gosimple
- ineffassign
- safesql
- staticcheck
- structcheck
- deadcode
- dupl
- errcheck
- unconvert
- unused
- golint
- lll
- misspell
- unparam
- goconst
- gocyclo
- interfacer
- gotype
- varcheck
- aligncheck
- gas
- goimports

I have not satisfied all of the warnings (high cyclomatic complexity, comments on all exported methods, etc.) because doing so requires more extensive changes that should really be addressed over time.