### PR TITLE
Fix Empty And/Or SQL Generation

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -73,10 +73,10 @@ type Eq map[string]interface{}
 
 func (eq Eq) toSql(useNotOpr bool) (sql string, args []interface{}, err error) {
 	var (
-		exprs      []string
-		equalOpr   = "="
-		inOpr      = "IN"
-		nullOpr    = "IS"
+		exprs       []string
+		equalOpr    = "="
+		inOpr       = "IN"
+		nullOpr     = "IS"
 		inEmptyExpr = "(1=0)" // Portable FALSE
 	)
 
@@ -217,7 +217,10 @@ func (gtOrEq GtOrEq) ToSql() (sql string, args []interface{}, err error) {
 
 type conj []Sqlizer
 
-func (c conj) join(sep string) (sql string, args []interface{}, err error) {
+func (c conj) join(sep, defaultExpr string) (sql string, args []interface{}, err error) {
+	if len(c) == 0 {
+		return defaultExpr, []interface{}{}, nil
+	}
 	var sqlParts []string
 	for _, sqlizer := range c {
 		partSql, partArgs, err := sqlizer.ToSql()
@@ -238,13 +241,13 @@ func (c conj) join(sep string) (sql string, args []interface{}, err error) {
 type And conj
 
 func (a And) ToSql() (string, []interface{}, error) {
-	return conj(a).join(" AND ")
+	return conj(a).join(" AND ", "(1=1)")
 }
 
 type Or conj
 
 func (o Or) ToSql() (string, []interface{}, error) {
-	return conj(o).join(" OR ")
+	return conj(o).join(" OR ", "(1=0)")
 }
 
 func isListType(val interface{}) bool {

--- a/expr_test.go
+++ b/expr_test.go
@@ -196,3 +196,25 @@ func TestNullTypeInt64(t *testing.T) {
 	assert.Equal(t, []interface{}{int64(10)}, args)
 	assert.Equal(t, "user_id = ?", sql)
 }
+
+func TestEmptyAndToSql(t *testing.T) {
+	sql, args, err := And{}.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "(1=1)"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestEmptyOrToSql(t *testing.T) {
+	sql, args, err := Or{}.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "(1=0)"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{}
+	assert.Equal(t, expectedArgs, args)
+}


### PR DESCRIPTION
Previously, these just generated `""` which could cause invalid SQL.  Using portable true/false for the empty case fixes this.