### PR TITLE
fix: nested select placeholders numbering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.7.x
   - 1.8.x
   - 1.9.x
   - tip

--- a/select.go
+++ b/select.go
@@ -52,6 +52,20 @@ func (d *selectData) QueryRow() RowScanner {
 }
 
 func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
+	sqlStr, args, err = d.toSql()
+	if err != nil {
+		return
+	}
+
+	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sqlStr)
+	return
+}
+
+func (d *selectData) toSqlRaw() (sqlStr string, args []interface{}, err error) {
+	return d.toSql()
+}
+
+func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 	if len(d.Columns) == 0 {
 		err = fmt.Errorf("select statements must have at least one result column")
 		return
@@ -135,7 +149,7 @@ func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
 		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
 	}
 
-	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
+	sqlStr = sql.String()
 	return
 }
 
@@ -192,6 +206,11 @@ func (b SelectBuilder) Scan(dest ...interface{}) error {
 func (b SelectBuilder) ToSql() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(selectData)
 	return data.ToSql()
+}
+
+func (b SelectBuilder) toSqlRaw() (string, []interface{}, error) {
+	data := builder.GetStruct(b).(selectData)
+	return data.toSqlRaw()
 }
 
 // Prefix adds an expression to the beginning of the query

--- a/select_test.go
+++ b/select_test.go
@@ -162,3 +162,13 @@ func TestSelectWithOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT DISTINCT SQL_NO_CACHE * FROM foo", sql)
 }
+
+func TestSelectBuilderNestedSelectDollar(t *testing.T) {
+	nestedBuilder := StatementBuilder.PlaceholderFormat(Dollar).Select("*").Prefix("NOT EXISTS (").
+		From("bar").Where("y = ?", 42).Suffix(")")
+	outerSql, _, err := StatementBuilder.PlaceholderFormat(Dollar).Select("*").
+		From("foo").Where("x = ?").Where(nestedBuilder).ToSql()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT * FROM foo WHERE x = $1 AND NOT EXISTS ( SELECT * FROM bar WHERE y = $2 )", outerSql)
+}

--- a/squirrel.go
+++ b/squirrel.go
@@ -20,6 +20,12 @@ type Sqlizer interface {
 	ToSql() (string, []interface{}, error)
 }
 
+// rawSqlizer is expected to do what Sqlizer does, but without finalizing placeholders.
+// This is useful for nested queries.
+type rawSqlizer interface {
+	toSqlRaw() (string, []interface{}, error)
+}
+
 // Execer is the interface that wraps the Exec method.
 //
 // Exec executes the given query as implemented by database/sql.Exec.

--- a/where.go
+++ b/where.go
@@ -14,6 +14,8 @@ func (p wherePart) ToSql() (sql string, args []interface{}, err error) {
 	switch pred := p.pred.(type) {
 	case nil:
 		// no-op
+	case rawSqlizer:
+		return pred.toSqlRaw()
 	case Sqlizer:
 		return pred.ToSql()
 	case map[string]interface{}:


### PR DESCRIPTION
This PR addresses [issue #128](https://github.com/Masterminds/squirrel/issues/128).

The fix goes as follows: for `wherePart`, we check if the predicate implements `RawSqlizer` with its `ToSqlRaw()` method. `ToSqlRaw()` does just what `ToSql()` does, but skips `PlaceholderFormat.ReplacePlaceholders()`.