### PR TITLE
sort eq and lt keys before toSql. To have consistency in toSql

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"reflect"
 	"strings"
+	"sort"
 )
 
 const (
@@ -99,8 +100,10 @@ func (eq Eq) toSql(useNotOpr bool) (sql string, args []interface{}, err error) {
 		inEmptyExpr = sqlTrue
 	}
 
-	for key, val := range eq {
+	sortedKeys := getSortedKeys(eq)
+	for _, key := range sortedKeys {
 		expr := ""
+		val := eq[key]
 
 		switch v := val.(type) {
 		case driver.Valuer:
@@ -168,8 +171,10 @@ func (lt Lt) toSql(opposite, orEq bool) (sql string, args []interface{}, err err
 		opr = fmt.Sprintf("%s%s", opr, "=")
 	}
 
-	for key, val := range lt {
+	sortedKeys := getSortedKeys(lt)
+	for _, key := range sortedKeys {
 		expr := ""
+		val := lt[key]
 
 		switch v := val.(type) {
 		case driver.Valuer:
@@ -260,6 +265,15 @@ type Or conj
 
 func (o Or) ToSql() (string, []interface{}, error) {
 	return conj(o).join(" OR ", sqlFalse)
+}
+
+func getSortedKeys(exp map[string]interface{}) []string {
+	sortedKeys := make([]string, 0, len(exp))
+	for k := range exp {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+	return sortedKeys
 }
 
 func isListType(val interface{}) bool {

--- a/expr_test.go
+++ b/expr_test.go
@@ -227,3 +227,27 @@ func TestEmptyOrToSql(t *testing.T) {
 	expectedArgs := []interface{}{}
 	assert.Equal(t, expectedArgs, args)
 }
+
+func TestSqlEqOrder(t *testing.T) {
+	b := Eq{"a": 1, "b": 2, "c": 3}
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "a = ? AND b = ? AND c = ?"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{1, 2, 3}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestSqlLtOrder(t *testing.T) {
+	b := Lt{"a": 1, "b": 2, "c": 3}
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "a < ? AND b < ? AND c < ?"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{1, 2, 3}
+	assert.Equal(t, expectedArgs, args)
+}


### PR DESCRIPTION
Sorted the keys of eq and lt and iterate over them rather on the maps.
It will help consistency in testing toSql

Fixes Issue #135 
