### PR TITLE
Adding Placeholder Colon format.

### DIFF
--- a/placeholder.go
+++ b/placeholder.go
@@ -22,6 +22,10 @@ var (
 	// Dollar is a PlaceholderFormat instance that replaces placeholders with
 	// dollar-prefixed positional placeholders (e.g. $1, $2, $3).
 	Dollar = dollarFormat{}
+
+	// Colon is a PlaceholderFormat instance that replaces placeholders with
+	// colon-prefixed positional placeholders (e.g. :1, :2, :3).
+	Colon = colonFormat{}
 )
 
 type questionFormat struct{}
@@ -52,6 +56,36 @@ func (_ dollarFormat) ReplacePlaceholders(sql string) (string, error) {
 			i++
 			buf.WriteString(sql[:p])
 			fmt.Fprintf(buf, "$%d", i)
+			sql = sql[p+1:]
+		}
+	}
+
+	buf.WriteString(sql)
+	return buf.String(), nil
+}
+
+type colonFormat struct{}
+
+func (_ colonFormat) ReplacePlaceholders(sql string) (string, error) {
+	buf := &bytes.Buffer{}
+	i := 0
+	for {
+		p := strings.Index(sql, "?")
+		if p == -1 {
+			break
+		}
+
+		if len(sql[p:]) > 1 && sql[p:p+2] == "??" { // escape ?? => ?
+			buf.WriteString(sql[:p])
+			buf.WriteString("?")
+			if len(sql[p:]) == 1 {
+				break
+			}
+			sql = sql[p+2:]
+		} else {
+			i++
+			buf.WriteString(sql[:p])
+			fmt.Fprintf(buf, ":%d", i)
 			sql = sql[p+1:]
 		}
 	}

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -19,14 +19,26 @@ func TestDollar(t *testing.T) {
 	assert.Equal(t, "x = $1 AND y = $2", s)
 }
 
+func TestColon(t *testing.T) {
+	sql := "x = ? AND y = ?"
+	s, _ := Colon.ReplacePlaceholders(sql)
+	assert.Equal(t, "x = :1 AND y = :2", s)
+}
+
 func TestPlaceholders(t *testing.T) {
 	assert.Equal(t, Placeholders(2), "?,?")
 }
 
-func TestEscape(t *testing.T) {
+func TestEscapeDollar(t *testing.T) {
 	sql := "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ??| array['?'] AND enabled = ?"
 	s, _ := Dollar.ReplacePlaceholders(sql)
 	assert.Equal(t, "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ?| array['$1'] AND enabled = $2", s)
+}
+
+func TestEscapeColon(t *testing.T) {
+	sql := "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ??| array['?'] AND enabled = ?"
+	s, _ := Colon.ReplacePlaceholders(sql)
+	assert.Equal(t, "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ?| array[':1'] AND enabled = :2", s)
 }
 
 func BenchmarkPlaceholdersArray(b *testing.B) {

--- a/select_test.go
+++ b/select_test.go
@@ -78,6 +78,9 @@ func TestSelectBuilderPlaceholders(t *testing.T) {
 
 	sql, _, _ = b.PlaceholderFormat(Dollar).ToSql()
 	assert.Equal(t, "SELECT test WHERE x = $1 AND y = $2", sql)
+
+	sql, _, _ = b.PlaceholderFormat(Colon).ToSql()
+	assert.Equal(t, "SELECT test WHERE x = :1 AND y = :2", sql)
 }
 
 func TestSelectBuilderRunners(t *testing.T) {


### PR DESCRIPTION
Adding a Placeholder Colon Format for Oracle DB users.

This looks and acts exactly like the Dollar Place Holder for Postgres. Except instead of using `$` it uses `:`

See: https://github.com/Masterminds/squirrel/issues/138