### PR TITLE
allow 3rd party wrappers to be used as runners.

### DIFF
--- a/squirrel_ctx.go
+++ b/squirrel_ctx.go
@@ -32,12 +32,8 @@ type QueryRowerContext interface {
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner
 }
 
-func (r *dbRunner) QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner {
-	return r.DB.QueryRowContext(ctx, query, args...)
-}
-
-func (r *txRunner) QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner {
-	return r.Tx.QueryRowContext(ctx, query, args...)
+func (r *stdsqlRunner) QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner {
+	return r.stdsql.QueryRowContext(ctx, query, args...)
 }
 
 // ExecContextWith ExecContexts the SQL returned by s with db.


### PR DESCRIPTION
found this useful in my projects, can be used to remove the explicitly checking for sql.DB and sql.TX