### PR TITLE
Fix Context methods with stdsqlRunner

### DIFF
--- a/squirrel.go
+++ b/squirrel.go
@@ -63,9 +63,11 @@ type Runner interface {
 
 type stdsql interface {
 	Query(string, ...interface{}) (*sql.Rows, error)
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRow(string, ...interface{}) *sql.Row
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	QuetdsqlRryRowContext(context.Context, string, ...interface{}) *sql.Row
 	Exec(string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 }
 
 type stdsqlRunner struct {


### PR DESCRIPTION
QueryContext and ExecContext were omitted from the interface, breaking some existing code.

Fixes #162