### PR TITLE
Add ability to Clear() statement cache

### DIFF
--- a/stmtcacher.go
+++ b/stmtcacher.go
@@ -112,7 +112,7 @@ type stmtCacheProxy struct {
 	db *sql.DB
 }
 
-func NewStmtCacherProxy(db *sql.DB) DBProxyBeginner {
+func NewStmtCacheProxy(db *sql.DB) DBProxyBeginner {
 	return &stmtCacheProxy{DBProxy: NewStmtCache(db), db: db}
 }
 

--- a/stmtcacher.go
+++ b/stmtcacher.go
@@ -94,6 +94,10 @@ func (sc *stmtCacher) Close() error {
 	sc.closed = true
 
 	for _, stmt := range sc.cache {
+		if stmt == nil {
+			continue
+		}
+
 		if err := stmt.Close(); err != nil {
 			return err
 		}

--- a/stmtcacher.go
+++ b/stmtcacher.go
@@ -2,6 +2,7 @@ package squirrel
 
 import (
 	"database/sql"
+	"fmt"
 	"sync"
 )
 
@@ -81,7 +82,7 @@ func (sc *stmtCacher) QueryRow(query string, args ...interface{}) RowScanner {
 	return stmt.QueryRow(args...)
 }
 
-func (sc *stmtCacher) Clear() error {
+func (sc *stmtCacher) Clear() (err error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
@@ -92,13 +93,16 @@ func (sc *stmtCacher) Clear() error {
 			continue
 		}
 
-		if err := stmt.Close(); err != nil {
-			return err
+		if cerr := stmt.Close(); cerr != nil {
+			err = cerr
 		}
-
 	}
 
-	return nil
+	if err != nil {
+		return fmt.Errorf("one or more Stmt.Close failed; last error: %v", err)
+	}
+
+	return
 }
 
 type DBProxyBeginner interface {

--- a/stmtcacher_ctx.go
+++ b/stmtcacher_ctx.go
@@ -5,6 +5,7 @@ package squirrel
 import (
 	"context"
 	"database/sql"
+	"io"
 )
 
 // PrepareerContext is the interface that wraps the Prepare and PrepareContext methods.
@@ -22,6 +23,7 @@ type DBProxyContext interface {
 	Queryer
 	QueryRower
 	PreparerContext
+	io.Closer
 }
 
 // NewStmtCacher returns a DBProxy wrapping prep that caches Prepared Stmts.

--- a/stmtcacher_ctx.go
+++ b/stmtcacher_ctx.go
@@ -28,10 +28,12 @@ type DBProxyContext interface {
 //
 // Stmts are cached based on the string value of their queries.
 func NewStmtCacher(prep PreparerContext) DBProxyContext {
-	return &stmtCacher{prep: prep, cache: make(map[string]*sql.Stmt)}
+	return &StmtCacher{prep: prep, cache: make(map[string]*sql.Stmt)}
 }
 
-func (sc *stmtCacher) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+// PrepareContext delegates down to the underlying PreparerContext and caches the result
+// using the provided query as a key
+func (sc *StmtCacher) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
 	ctxPrep, ok := sc.prep.(PreparerContext)
 	if !ok {
 		return nil, NoContextSupport
@@ -49,7 +51,8 @@ func (sc *stmtCacher) PrepareContext(ctx context.Context, query string) (*sql.St
 	return stmt, err
 }
 
-func (sc *stmtCacher) ExecContext(ctx context.Context, query string, args ...interface{}) (res sql.Result, err error) {
+// ExecContext delegates down to the underlying PreparerContext using a prepared statement
+func (sc *StmtCacher) ExecContext(ctx context.Context, query string, args ...interface{}) (res sql.Result, err error) {
 	stmt, err := sc.PrepareContext(ctx, query)
 	if err != nil {
 		return
@@ -57,7 +60,8 @@ func (sc *stmtCacher) ExecContext(ctx context.Context, query string, args ...int
 	return stmt.ExecContext(ctx, args...)
 }
 
-func (sc *stmtCacher) QueryContext(ctx context.Context, query string, args ...interface{}) (rows *sql.Rows, err error) {
+// QueryContext delegates down to the underlying PreparerContext using a prepared statement
+func (sc *StmtCacher) QueryContext(ctx context.Context, query string, args ...interface{}) (rows *sql.Rows, err error) {
 	stmt, err := sc.PrepareContext(ctx, query)
 	if err != nil {
 		return
@@ -65,7 +69,8 @@ func (sc *stmtCacher) QueryContext(ctx context.Context, query string, args ...in
 	return stmt.QueryContext(ctx, args...)
 }
 
-func (sc *stmtCacher) QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner {
+// QueryRowContext delegates down to the underlying PreparerContext using a prepared statement
+func (sc *StmtCacher) QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner {
 	stmt, err := sc.PrepareContext(ctx, query)
 	if err != nil {
 		return &Row{err: err}

--- a/stmtcacher_ctx.go
+++ b/stmtcacher_ctx.go
@@ -5,7 +5,6 @@ package squirrel
 import (
 	"context"
 	"database/sql"
-	"io"
 )
 
 // PrepareerContext is the interface that wraps the Prepare and PrepareContext methods.
@@ -23,7 +22,6 @@ type DBProxyContext interface {
 	Queryer
 	QueryRower
 	PreparerContext
-	io.Closer
 }
 
 // NewStmtCacher returns a DBProxy wrapping prep that caches Prepared Stmts.

--- a/stmtcacher_ctx_test.go
+++ b/stmtcacher_ctx_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestStmtCacherPrepareContext(t *testing.T) {
 	db := &DBStub{}
-	sc := NewStmtCacher(db)
+	sc := NewStmtCache(db)
 	query := "SELECT 1"
 
 	sc.PrepareContext(ctx, query)

--- a/stmtcacher_noctx.go
+++ b/stmtcacher_noctx.go
@@ -10,5 +10,5 @@ import (
 //
 // Stmts are cached based on the string value of their queries.
 func NewStmtCacher(prep Preparer) DBProxy {
-	return &stmtCacher{prep: prep, cache: make(map[string]*sql.Stmt)}
+	return &StmtCacher{prep: prep, cache: make(map[string]*sql.Stmt)}
 }

--- a/stmtcacher_noctx.go
+++ b/stmtcacher_noctx.go
@@ -9,6 +9,13 @@ import (
 // NewStmtCacher returns a DBProxy wrapping prep that caches Prepared Stmts.
 //
 // Stmts are cached based on the string value of their queries.
-func NewStmtCacher(prep Preparer) DBProxy {
+func NewStmtCache(prep Preparer) *StmtCache {
 	return &StmtCacher{prep: prep, cache: make(map[string]*sql.Stmt)}
+}
+
+// NewStmtCacher is deprecated
+//
+// Use NewStmtCache instead
+func NewStmtCacher(prep Preparer) DBProxy {
+	return NewStmtCache(prep)
 }

--- a/stmtcacher_test.go
+++ b/stmtcacher_test.go
@@ -16,4 +16,10 @@ func TestStmtCacherPrepare(t *testing.T) {
 
 	sc.Prepare(query)
 	assert.Equal(t, 1, db.PrepareCount, "expected 1 Prepare, got %d", db.PrepareCount)
+
+	assert.Nil(t, sc.Close())
+
+	_, err := sc.Prepare(query)
+	assert.Error(t, err, "statement cache closed")
+	assert.Equal(t, 1, db.PrepareCount, "expected 1 Prepare, got %d", db.PrepareCount)
 }

--- a/stmtcacher_test.go
+++ b/stmtcacher_test.go
@@ -4,12 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestStmtCacherPrepare(t *testing.T) {
+func TestStmtCachePrepare(t *testing.T) {
 	db := &DBStub{}
-	sc := NewStmtCacher(db)
+	sc := NewStmtCache(db)
 	query := "SELECT 1"
 
 	sc.Prepare(query)
@@ -19,9 +18,7 @@ func TestStmtCacherPrepare(t *testing.T) {
 	assert.Equal(t, 1, db.PrepareCount, "expected 1 Prepare, got %d", db.PrepareCount)
 
 	// clear statement cache
-	clearer, ok := sc.(*StmtCacher)
-	require.True(t, ok)
-	assert.Nil(t, clearer.Clear())
+	assert.Nil(t, sc.Clear())
 
 	// should prepare the query again
 	sc.Prepare(query)

--- a/stmtcacher_test.go
+++ b/stmtcacher_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStmtCacherPrepare(t *testing.T) {
@@ -17,9 +18,12 @@ func TestStmtCacherPrepare(t *testing.T) {
 	sc.Prepare(query)
 	assert.Equal(t, 1, db.PrepareCount, "expected 1 Prepare, got %d", db.PrepareCount)
 
-	assert.Nil(t, sc.Close())
+	// clear statement cache
+	clearer, ok := sc.(DBProxyClearer)
+	require.True(t, ok)
+	assert.Nil(t, clearer.Clear())
 
-	_, err := sc.Prepare(query)
-	assert.Error(t, err, "statement cache closed")
-	assert.Equal(t, 1, db.PrepareCount, "expected 1 Prepare, got %d", db.PrepareCount)
+	// should prepare the query again
+	sc.Prepare(query)
+	assert.Equal(t, 2, db.PrepareCount, "expected 2 Prepare, got %d", db.PrepareCount)
 }

--- a/stmtcacher_test.go
+++ b/stmtcacher_test.go
@@ -19,7 +19,7 @@ func TestStmtCacherPrepare(t *testing.T) {
 	assert.Equal(t, 1, db.PrepareCount, "expected 1 Prepare, got %d", db.PrepareCount)
 
 	// clear statement cache
-	clearer, ok := sc.(DBProxyClearer)
+	clearer, ok := sc.(*StmtCacher)
 	require.True(t, ok)
 	assert.Nil(t, clearer.Clear())
 


### PR DESCRIPTION
Due to some poor handling in my own codebase. I started creating lots of `*stmtCacher` instances.

While I was quickly discarding them I noticed that memory started to leak wherever something interacted with the shared `*sql.DB` connection pool. Upon revisiting the change made, I noticed we were creating all these proxy instances and started to wonder why even though these would get garbage collected memory kept growing. This lead me to realise that *sql.DB keeps its own pool of prepared statements: https://golang.org/src/database/sql/sql.go#L438

So I implemented this change just to validate that closing all those statements got rid of my memory issues and it did.

This change adds Close to:
- DBProxy
- DBProxyContext
- *stmtCacher

A call to *stmtCacher.Close will intentionally not close any connections. Rather it just loops over the statement cache map and calls close on each `*sql.Stmt`. Not sure if this is desirable for everyone, but it worked nicely for my situation where I wanted to have that control (i.e. closing the statements not the connections). It also makes the proxy as closed so it can't be reused.

Love to hear your thoughts on this change 🙇 

UPDATE (26th Feb 2019): Renamed Close -> Clear and removed Close from DBProxy interface

Instead Clear can be obtained by an interface upgrade on `DBProxy` to `DBProxyClearer`.