### PR TITLE
Add support to between expression

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -161,6 +161,19 @@ func (neq NotEq) ToSql() (sql string, args []interface{}, err error) {
 	return Eq(neq).toSQL(true)
 }
 
+// Between is syntactic sugar for use with BETWEEN methods.
+// Ex:
+//     .Where(Between{field: "id", left: 1, right: 5}) == "id between 1 and 5"
+type Between struct {
+	field string
+	left  interface{}
+	right interface{}
+}
+
+func (between Between) ToSql() (sql string, args []interface{}, err error) {
+	return fmt.Sprintf("%s BETWEEN ? AND ?", between.field), []interface{}{between.left, between.right}, nil
+}
+
 // Like is syntactic sugar for use with LIKE conditions.
 // Ex:
 //     .Where(Like{"name": "%irrel"})

--- a/expr_test.go
+++ b/expr_test.go
@@ -22,7 +22,7 @@ func TestEqToSql(t *testing.T) {
 func TestEqEmptyToSql(t *testing.T) {
 	sql, args, err := Eq{}.ToSql()
 	assert.NoError(t, err)
-	
+
 	expectedSql := "(1=1)"
 	assert.Equal(t, expectedSql, sql)
 	assert.Empty(t, args)
@@ -145,6 +145,22 @@ func TestGtOrEqToSql(t *testing.T) {
 	assert.Equal(t, expectedSql, sql)
 
 	expectedArgs := []interface{}{1}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestBetweenToSql(t *testing.T) {
+	between := Between{
+		field: "id",
+		left:  1,
+		right: 5,
+	}
+	sql, args, err := between.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "id BETWEEN ? AND ?"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{1, 5}
 	assert.Equal(t, expectedArgs, args)
 }
 


### PR DESCRIPTION
This PR add a new Sqlizer called Between

Example: WHERE id BETWEEN 1 AND 5
```
.Where(Between{
  field: "id",
  left:  1,
  right: 5,
}
```