### PR TITLE
SelectBuilder.RemoveOffset method added.

### DIFF
--- a/select.go
+++ b/select.go
@@ -354,6 +354,11 @@ func (b SelectBuilder) Offset(offset uint64) SelectBuilder {
 	return builder.Set(b, "Offset", fmt.Sprintf("%d", offset)).(SelectBuilder)
 }
 
+// RemoveOffset removes OFFSET clause.
+func (b SelectBuilder) RemoveOffset() SelectBuilder {
+	return builder.Delete(b, "Offset").(SelectBuilder)
+}
+
 // Suffix adds an expression to the end of the query
 func (b SelectBuilder) Suffix(sql string, args ...interface{}) SelectBuilder {
 	return builder.Append(b, "Suffixes", Expr(sql, args...)).(SelectBuilder)

--- a/select_test.go
+++ b/select_test.go
@@ -174,6 +174,13 @@ func TestSelectWithRemoveLimit(t *testing.T) {
 	assert.Equal(t, "SELECT * FROM foo", sql)
 }
 
+func TestSelectWithRemoveOffset(t *testing.T) {
+	sql, _, err := Select("*").From("foo").Offset(10).RemoveOffset().ToSql()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT * FROM foo", sql)
+}
+
 func TestSelectBuilderNestedSelectDollar(t *testing.T) {
 	nestedBuilder := StatementBuilder.PlaceholderFormat(Dollar).Select("*").Prefix("NOT EXISTS (").
 		From("bar").Where("y = ?", 42).Suffix(")")


### PR DESCRIPTION
Hi.

`OFFSET` without `LIMIT` has no meaning in MySQL and cause of syntax error. And I see no ways to remove it. So I suggest to add `RemoveOffset` method.