### PR TITLE
Fix linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ users := sq.Select("*").From("users").Join("emails USING (email_id)")
 
 active := users.Where(sq.Eq{"deleted_at": nil})
 
-sql, args, err := active.ToSql()
+sql, args, err := active.ToSQL()
 
 sql == "SELECT * FROM users JOIN emails USING (email_id) WHERE deleted_at IS NULL"
 ```
@@ -33,7 +33,7 @@ sql == "SELECT * FROM users JOIN emails USING (email_id) WHERE deleted_at IS NUL
 sql, args, err := sq.
     Insert("users").Columns("name", "age").
     Values("moe", 13).Values("larry", sq.Expr("? + 5", 12)).
-    ToSql()
+    ToSQL()
 
 sql == "INSERT INTO users (name,age) VALUES (?,?),(?,? + 5)"
 ```
@@ -75,7 +75,7 @@ Squirrel loves PostgreSQL:
 psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 // You use question marks for placeholders...
-sql, _, _ := psql.Select("*").From("elephants").Where("name IN (?,?)", "Dumbo", "Verna").ToSql()
+sql, _, _ := psql.Select("*").From("elephants").Where("name IN (?,?)", "Dumbo", "Verna").ToSQL()
 
 /// ...squirrel replaces them using PlaceholderFormat.
 sql == "SELECT * FROM elephants WHERE name IN ($1,$2)"

--- a/case.go
+++ b/case.go
@@ -27,7 +27,7 @@ func (b *sqlizerBuffer) WriteSql(item Sqlizer) {
 
 	var str string
 	var args []interface{}
-	str, args, b.err = item.ToSql()
+	str, args, b.err = item.ToSQL()
 
 	if b.err != nil {
 		return
@@ -38,7 +38,7 @@ func (b *sqlizerBuffer) WriteSql(item Sqlizer) {
 	b.args = append(b.args, args...)
 }
 
-func (b *sqlizerBuffer) ToSql() (string, []interface{}, error) {
+func (b *sqlizerBuffer) ToSQL() (string, []interface{}, error) {
 	return b.String(), b.args, b.err
 }
 
@@ -59,8 +59,8 @@ type caseData struct {
 	Else      Sqlizer
 }
 
-// ToSql implements Sqlizer
-func (d *caseData) ToSql() (sqlStr string, args []interface{}, err error) {
+// ToSQL implements Sqlizer
+func (d *caseData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	if len(d.WhenParts) == 0 {
 		err = errors.New("case expression must contain at lease one WHEN clause")
 
@@ -88,16 +88,16 @@ func (d *caseData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	sql.WriteString("END")
 
-	return sql.ToSql()
+	return sql.ToSQL()
 }
 
 // CaseBuilder builds SQL CASE construct which could be used as parts of queries.
 type CaseBuilder builder.Builder
 
-// ToSql builds the query into a SQL string and bound args.
-func (b CaseBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b CaseBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(caseData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 // what sets optional value for CASE construct "CASE [value] ..."

--- a/case_test.go
+++ b/case_test.go
@@ -15,7 +15,7 @@ func TestCaseWithVal(t *testing.T) {
 	qb := Select().
 		Column(caseStmt).
 		From("table")
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
@@ -38,7 +38,7 @@ func TestCaseWithComplexVal(t *testing.T) {
 	qb := Select().
 		Column(Alias(caseStmt, "complexCase")).
 		From("table")
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
@@ -58,7 +58,7 @@ func TestCaseWithNoVal(t *testing.T) {
 		When(Expr("x > ?", 1), Expr("CONCAT('x is greater than ', ?)", 2))
 
 	qb := Select().Column(caseStmt).From("table")
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
@@ -80,7 +80,7 @@ func TestCaseWithExpr(t *testing.T) {
 		Else("42")
 
 	qb := Select().Column(caseStmt).From("table")
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
@@ -109,7 +109,7 @@ func TestMultipleCase(t *testing.T) {
 		Column(Alias(caseStmtExpr, "case_expr")).
 		From("table")
 
-	sql, args, err := qb.ToSql()
+	sql, args, err := qb.ToSQL()
 
 	assert.NoError(t, err)
 
@@ -133,7 +133,7 @@ func TestCaseWithNoWhenClause(t *testing.T) {
 
 	qb := Select().Column(caseStmt).From("table")
 
-	_, _, err := qb.ToSql()
+	_, _, err := qb.ToSQL()
 
 	assert.Error(t, err)
 

--- a/delete.go
+++ b/delete.go
@@ -28,7 +28,7 @@ func (d *deleteData) Exec() (sql.Result, error) {
 	return ExecWith(d.RunWith, d)
 }
 
-func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
+func (d *deleteData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	if len(d.From) == 0 {
 		err = fmt.Errorf("delete statements must specify a From table")
 		return
@@ -37,7 +37,7 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, _ = d.Prefixes.AppendToSQL(sql, " ", args)
 		sql.WriteString(" ")
 	}
 
@@ -46,7 +46,7 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.WhereParts) > 0 {
 		sql.WriteString(" WHERE ")
-		args, err = appendToSql(d.WhereParts, sql, " AND ", args)
+		args, err = appendToSQL(d.WhereParts, sql, " AND ", args)
 		if err != nil {
 			return
 		}
@@ -69,7 +69,7 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, _ = d.Suffixes.AppendToSQL(sql, " ", args)
 	}
 
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
@@ -108,10 +108,10 @@ func (b DeleteBuilder) Exec() (sql.Result, error) {
 
 // SQL methods
 
-// ToSql builds the query into a SQL string and bound args.
-func (b DeleteBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b DeleteBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(deleteData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 // Prefix adds an expression to the beginning of the query

--- a/delete_test.go
+++ b/delete_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeleteBuilderToSql(t *testing.T) {
+func TestDeleteBuilderToSQL(t *testing.T) {
 	b := Delete("").
 		Prefix("WITH prefix AS ?", 0).
 		From("a").
@@ -16,7 +16,7 @@ func TestDeleteBuilderToSql(t *testing.T) {
 		Offset(3).
 		Suffix("RETURNING ?", 4)
 
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql :=
@@ -29,18 +29,18 @@ func TestDeleteBuilderToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestDeleteBuilderToSqlErr(t *testing.T) {
-	_, _, err := Delete("").ToSql()
+func TestDeleteBuilderToSQLErr(t *testing.T) {
+	_, _, err := Delete("").ToSQL()
 	assert.Error(t, err)
 }
 
 func TestDeleteBuilderPlaceholders(t *testing.T) {
 	b := Delete("test").Where("x = ? AND y = ?", 1, 2)
 
-	sql, _, _ := b.PlaceholderFormat(Question).ToSql()
+	sql, _, _ := b.PlaceholderFormat(Question).ToSQL()
 	assert.Equal(t, "DELETE FROM test WHERE x = ? AND y = ?", sql)
 
-	sql, _, _ = b.PlaceholderFormat(Dollar).ToSql()
+	sql, _, _ = b.PlaceholderFormat(Dollar).ToSQL()
 	assert.Equal(t, "DELETE FROM test WHERE x = $1 AND y = $2", sql)
 }
 

--- a/expr.go
+++ b/expr.go
@@ -28,13 +28,13 @@ func Expr(sql string, args ...interface{}) expr {
 	return expr{sql: sql, args: args}
 }
 
-func (e expr) ToSql() (sql string, args []interface{}, err error) {
+func (e expr) ToSQL() (sql string, args []interface{}, err error) {
 	return e.sql, e.args, nil
 }
 
 type exprs []expr
 
-func (es exprs) AppendToSql(w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
+func (es exprs) AppendToSQL(w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
 	for i, e := range es {
 		if i > 0 {
 			_, err := io.WriteString(w, sep)
@@ -65,8 +65,8 @@ func Alias(expr Sqlizer, alias string) aliasExpr {
 	return aliasExpr{expr, alias}
 }
 
-func (e aliasExpr) ToSql() (sql string, args []interface{}, err error) {
-	sql, args, err = e.expr.ToSql()
+func (e aliasExpr) ToSQL() (sql string, args []interface{}, err error) {
+	sql, args, err = e.expr.ToSQL()
 	if err == nil {
 		sql = fmt.Sprintf("(%s) AS %s", sql, e.alias)
 	}
@@ -148,7 +148,7 @@ func (eq Eq) toSQL(useNotOpr bool) (sql string, args []interface{}, err error) {
 	return
 }
 
-func (eq Eq) ToSql() (sql string, args []interface{}, err error) {
+func (eq Eq) ToSQL() (sql string, args []interface{}, err error) {
 	return eq.toSQL(false)
 }
 
@@ -157,7 +157,7 @@ func (eq Eq) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(NotEq{"id": 1}) == "id <> 1"
 type NotEq Eq
 
-func (neq NotEq) ToSql() (sql string, args []interface{}, err error) {
+func (neq NotEq) ToSQL() (sql string, args []interface{}, err error) {
 	return Eq(neq).toSQL(true)
 }
 
@@ -204,7 +204,7 @@ func (lk Like) toSql(opposite bool) (sql string, args []interface{}, err error) 
 	return
 }
 
-func (lk Like) ToSql() (sql string, args []interface{}, err error) {
+func (lk Like) ToSQL() (sql string, args []interface{}, err error) {
 	return lk.toSql(false)
 }
 
@@ -213,7 +213,7 @@ func (lk Like) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(NotLike{"name": "%irrel"})
 type NotLike Like
 
-func (nlk NotLike) ToSql() (sql string, args []interface{}, err error) {
+func (nlk NotLike) ToSQL() (sql string, args []interface{}, err error) {
 	return Like(nlk).toSql(true)
 }
 
@@ -265,7 +265,7 @@ func (lt Lt) toSql(opposite, orEq bool) (sql string, args []interface{}, err err
 	return
 }
 
-func (lt Lt) ToSql() (sql string, args []interface{}, err error) {
+func (lt Lt) ToSQL() (sql string, args []interface{}, err error) {
 	return lt.toSql(false, false)
 }
 
@@ -274,7 +274,7 @@ func (lt Lt) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(LtOrEq{"id": 1}) == "id <= 1"
 type LtOrEq Lt
 
-func (ltOrEq LtOrEq) ToSql() (sql string, args []interface{}, err error) {
+func (ltOrEq LtOrEq) ToSQL() (sql string, args []interface{}, err error) {
 	return Lt(ltOrEq).toSql(false, true)
 }
 
@@ -283,7 +283,7 @@ func (ltOrEq LtOrEq) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(Gt{"id": 1}) == "id > 1"
 type Gt Lt
 
-func (gt Gt) ToSql() (sql string, args []interface{}, err error) {
+func (gt Gt) ToSQL() (sql string, args []interface{}, err error) {
 	return Lt(gt).toSql(true, false)
 }
 
@@ -292,7 +292,7 @@ func (gt Gt) ToSql() (sql string, args []interface{}, err error) {
 //     .Where(GtOrEq{"id": 1}) == "id >= 1"
 type GtOrEq Lt
 
-func (gtOrEq GtOrEq) ToSql() (sql string, args []interface{}, err error) {
+func (gtOrEq GtOrEq) ToSQL() (sql string, args []interface{}, err error) {
 	return Lt(gtOrEq).toSql(true, true)
 }
 
@@ -304,7 +304,7 @@ func (c conj) join(sep, defaultExpr string) (sql string, args []interface{}, err
 	}
 	var sqlParts []string
 	for _, sqlizer := range c {
-		partSQL, partArgs, err := sqlizer.ToSql()
+		partSQL, partArgs, err := sqlizer.ToSQL()
 		if err != nil {
 			return "", nil, err
 		}
@@ -322,14 +322,14 @@ func (c conj) join(sep, defaultExpr string) (sql string, args []interface{}, err
 // And conjunction Sqlizers
 type And conj
 
-func (a And) ToSql() (string, []interface{}, error) {
+func (a And) ToSQL() (string, []interface{}, error) {
 	return conj(a).join(" AND ", sqlTrue)
 }
 
 // Or conjunction Sqlizers
 type Or conj
 
-func (o Or) ToSql() (string, []interface{}, error) {
+func (o Or) ToSQL() (string, []interface{}, error) {
 	return conj(o).join(" OR ", sqlFalse)
 }
 

--- a/expr_test.go
+++ b/expr_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEqToSql(t *testing.T) {
+func TestEqToSQL(t *testing.T) {
 	b := Eq{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "id = ?"
@@ -19,8 +19,8 @@ func TestEqToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestEqEmptyToSql(t *testing.T) {
-	sql, args, err := Eq{}.ToSql()
+func TestEqEmptyToSQL(t *testing.T) {
+	sql, args, err := Eq{}.ToSQL()
 	assert.NoError(t, err)
 	
 	expectedSql := "(1=1)"
@@ -28,9 +28,9 @@ func TestEqEmptyToSql(t *testing.T) {
 	assert.Empty(t, args)
 }
 
-func TestEqInToSql(t *testing.T) {
+func TestEqInToSQL(t *testing.T) {
 	b := Eq{"id": []int{1, 2, 3}}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "id IN (?,?,?)"
@@ -40,9 +40,9 @@ func TestEqInToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestNotEqToSql(t *testing.T) {
+func TestNotEqToSQL(t *testing.T) {
 	b := NotEq{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "id <> ?"
@@ -52,9 +52,9 @@ func TestNotEqToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestEqNotInToSql(t *testing.T) {
+func TestEqNotInToSQL(t *testing.T) {
 	b := NotEq{"id": []int{1, 2, 3}}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "id NOT IN (?,?,?)"
@@ -64,9 +64,9 @@ func TestEqNotInToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestEqInEmptyToSql(t *testing.T) {
+func TestEqInEmptyToSQL(t *testing.T) {
 	b := Eq{"id": []int{}}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "(1=0)"
@@ -76,9 +76,9 @@ func TestEqInEmptyToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestNotEqInEmptyToSql(t *testing.T) {
+func TestNotEqInEmptyToSQL(t *testing.T) {
 	b := NotEq{"id": []int{}}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "(1=1)"
@@ -88,9 +88,9 @@ func TestNotEqInEmptyToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestEqBytesToSql(t *testing.T) {
+func TestEqBytesToSQL(t *testing.T) {
 	b := Eq{"id": []byte("test")}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "id = ?"
@@ -100,9 +100,9 @@ func TestEqBytesToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestLtToSql(t *testing.T) {
+func TestLtToSQL(t *testing.T) {
 	b := Lt{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "id < ?"
@@ -112,9 +112,9 @@ func TestLtToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestLtOrEqToSql(t *testing.T) {
+func TestLtOrEqToSQL(t *testing.T) {
 	b := LtOrEq{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "id <= ?"
@@ -124,9 +124,9 @@ func TestLtOrEqToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestGtToSql(t *testing.T) {
+func TestGtToSQL(t *testing.T) {
 	b := Gt{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "id > ?"
@@ -136,9 +136,9 @@ func TestGtToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestGtOrEqToSql(t *testing.T) {
+func TestGtOrEqToSQL(t *testing.T) {
 	b := GtOrEq{"id": 1}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "id >= ?"
@@ -148,10 +148,10 @@ func TestGtOrEqToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestExprNilToSql(t *testing.T) {
+func TestExprNilToSQL(t *testing.T) {
 	var b Sqlizer
 	b = NotEq{"name": nil}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 
@@ -159,7 +159,7 @@ func TestExprNilToSql(t *testing.T) {
 	assert.Equal(t, expectedSql, sql)
 
 	b = Eq{"name": nil}
-	sql, args, err = b.ToSql()
+	sql, args, err = b.ToSQL()
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 
@@ -172,7 +172,7 @@ func TestNullTypeString(t *testing.T) {
 	var name sql.NullString
 
 	b = Eq{"name": name}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Empty(t, args)
@@ -180,7 +180,7 @@ func TestNullTypeString(t *testing.T) {
 
 	name.Scan("Name")
 	b = Eq{"name": name}
-	sql, args, err = b.ToSql()
+	sql, args, err = b.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{"Name"}, args)
@@ -191,7 +191,7 @@ func TestNullTypeInt64(t *testing.T) {
 	var userID sql.NullInt64
 	userID.Scan(nil)
 	b := Eq{"user_id": userID}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Empty(t, args)
@@ -199,7 +199,7 @@ func TestNullTypeInt64(t *testing.T) {
 
 	userID.Scan(int64(10))
 	b = Eq{"user_id": userID}
-	sql, args, err = b.ToSql()
+	sql, args, err = b.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{int64(10)}, args)
@@ -209,14 +209,14 @@ func TestNullTypeInt64(t *testing.T) {
 func TestNilPointer(t *testing.T) {
 	var name *string = nil
 	eq := Eq{"name": name}
-	sql, args, err := eq.ToSql()
+	sql, args, err := eq.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 	assert.Equal(t, "name IS NULL", sql)
 
 	neq := NotEq{"name": name}
-	sql, args, err = neq.ToSql()
+	sql, args, err = neq.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Empty(t, args)
@@ -224,26 +224,26 @@ func TestNilPointer(t *testing.T) {
 
 	var ids *[]int = nil
 	eq = Eq{"id": ids}
-	sql, args, err = eq.ToSql()
+	sql, args, err = eq.ToSQL()
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 	assert.Equal(t, "id IS NULL", sql)
 
 	neq = NotEq{"id": ids}
-	sql, args, err = neq.ToSql()
+	sql, args, err = neq.ToSQL()
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 	assert.Equal(t, "id IS NOT NULL", sql)
 
 	var ida *[3]int = nil
 	eq = Eq{"id": ida}
-	sql, args, err = eq.ToSql()
+	sql, args, err = eq.ToSQL()
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 	assert.Equal(t, "id IS NULL", sql)
 
 	neq = NotEq{"id": ida}
-	sql, args, err = neq.ToSql()
+	sql, args, err = neq.ToSQL()
 	assert.NoError(t, err)
 	assert.Empty(t, args)
 	assert.Equal(t, "id IS NOT NULL", sql)
@@ -254,14 +254,14 @@ func TestNotNilPointer(t *testing.T) {
 	c := "Name"
 	name := &c
 	eq := Eq{"name": name}
-	sql, args, err := eq.ToSql()
+	sql, args, err := eq.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{"Name"}, args)
 	assert.Equal(t, "name = ?", sql)
 
 	neq := NotEq{"name": name}
-	sql, args, err = neq.ToSql()
+	sql, args, err = neq.ToSQL()
 
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{"Name"}, args)
@@ -270,13 +270,13 @@ func TestNotNilPointer(t *testing.T) {
 	s := []int{1, 2, 3}
 	ids := &s
 	eq = Eq{"id": ids}
-	sql, args, err = eq.ToSql()
+	sql, args, err = eq.ToSQL()
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{1, 2, 3}, args)
 	assert.Equal(t, "id IN (?,?,?)", sql)
 
 	neq = NotEq{"id": ids}
-	sql, args, err = neq.ToSql()
+	sql, args, err = neq.ToSQL()
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{1, 2, 3}, args)
 	assert.Equal(t, "id NOT IN (?,?,?)", sql)
@@ -284,20 +284,20 @@ func TestNotNilPointer(t *testing.T) {
 	a := [3]int{1, 2, 3}
 	ida := &a
 	eq = Eq{"id": ida}
-	sql, args, err = eq.ToSql()
+	sql, args, err = eq.ToSQL()
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{1, 2, 3}, args)
 	assert.Equal(t, "id IN (?,?,?)", sql)
 
 	neq = NotEq{"id": ida}
-	sql, args, err = neq.ToSql()
+	sql, args, err = neq.ToSQL()
 	assert.NoError(t, err)
 	assert.Equal(t, []interface{}{1, 2, 3}, args)
 	assert.Equal(t, "id NOT IN (?,?,?)", sql)
 }
 
-func TestEmptyAndToSql(t *testing.T) {
-	sql, args, err := And{}.ToSql()
+func TestEmptyAndToSQL(t *testing.T) {
+	sql, args, err := And{}.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "(1=1)"
@@ -307,8 +307,8 @@ func TestEmptyAndToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestEmptyOrToSql(t *testing.T) {
-	sql, args, err := Or{}.ToSql()
+func TestEmptyOrToSQL(t *testing.T) {
+	sql, args, err := Or{}.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "(1=0)"
@@ -318,9 +318,9 @@ func TestEmptyOrToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestLikeToSql(t *testing.T) {
+func TestLikeToSQL(t *testing.T) {
 	b := Like{"name": "%irrel"}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "name LIKE ?"
@@ -330,9 +330,9 @@ func TestLikeToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestNotLikeToSql(t *testing.T) {
+func TestNotLikeToSQL(t *testing.T) {
 	b := NotLike{"name": "%irrel"}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "name NOT LIKE ?"
@@ -344,7 +344,7 @@ func TestNotLikeToSql(t *testing.T) {
 
 func TestSqlEqOrder(t *testing.T) {
 	b := Eq{"a": 1, "b": 2, "c": 3}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "a = ? AND b = ? AND c = ?"
@@ -356,7 +356,7 @@ func TestSqlEqOrder(t *testing.T) {
 
 func TestSqlLtOrder(t *testing.T) {
 	b := Lt{"a": 1, "b": 2, "c": 3}
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql := "a < ? AND b < ? AND c < ?"

--- a/insert.go
+++ b/insert.go
@@ -49,7 +49,7 @@ func (d *insertData) QueryRow() RowScanner {
 	return QueryRowWith(queryRower, d)
 }
 
-func (d *insertData) ToSql() (sqlStr string, args []interface{}, err error) {
+func (d *insertData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	if len(d.Into) == 0 {
 		err = errors.New("insert statements must specify a table")
 		return
@@ -62,7 +62,7 @@ func (d *insertData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, _ = d.Prefixes.AppendToSQL(sql, " ", args)
 		sql.WriteString(" ")
 	}
 
@@ -94,7 +94,7 @@ func (d *insertData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, _ = d.Suffixes.AppendToSQL(sql, " ", args)
 	}
 
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
@@ -134,7 +134,7 @@ func (d *insertData) appendSelectToSQL(w io.Writer, args []interface{}) ([]inter
 		return args, errors.New("select clause for insert statements are not set")
 	}
 
-	selectClause, sArgs, err := d.Select.ToSql()
+	selectClause, sArgs, err := d.Select.ToSQL()
 	if err != nil {
 		return args, err
 	}
@@ -194,10 +194,10 @@ func (b InsertBuilder) Scan(dest ...interface{}) error {
 
 // SQL methods
 
-// ToSql builds the query into a SQL string and bound args.
-func (b InsertBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b InsertBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(insertData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 // Prefix adds an expression to the beginning of the query

--- a/insert_test.go
+++ b/insert_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInsertBuilderToSql(t *testing.T) {
+func TestInsertBuilderToSQL(t *testing.T) {
 	b := Insert("").
 		Prefix("WITH prefix AS ?", 0).
 		Into("a").
@@ -16,7 +16,7 @@ func TestInsertBuilderToSql(t *testing.T) {
 		Values(3, Expr("? + 1", 4)).
 		Suffix("RETURNING ?", 5)
 
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSQL :=
@@ -29,21 +29,21 @@ func TestInsertBuilderToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestInsertBuilderToSqlErr(t *testing.T) {
-	_, _, err := Insert("").Values(1).ToSql()
+func TestInsertBuilderToSQLErr(t *testing.T) {
+	_, _, err := Insert("").Values(1).ToSQL()
 	assert.Error(t, err)
 
-	_, _, err = Insert("x").ToSql()
+	_, _, err = Insert("x").ToSQL()
 	assert.Error(t, err)
 }
 
 func TestInsertBuilderPlaceholders(t *testing.T) {
 	b := Insert("test").Values(1, 2)
 
-	sql, _, _ := b.PlaceholderFormat(Question).ToSql()
+	sql, _, _ := b.PlaceholderFormat(Question).ToSQL()
 	assert.Equal(t, "INSERT INTO test VALUES (?,?)", sql)
 
-	sql, _, _ = b.PlaceholderFormat(Dollar).ToSql()
+	sql, _, _ = b.PlaceholderFormat(Dollar).ToSQL()
 	assert.Equal(t, "INSERT INTO test VALUES ($1,$2)", sql)
 }
 
@@ -67,7 +67,7 @@ func TestInsertBuilderNoRunner(t *testing.T) {
 func TestInsertBuilderSetMap(t *testing.T) {
 	b := Insert("table").SetMap(Eq{"field1": 1, "field2": 2, "field3": 3})
 
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSQL := "INSERT INTO table (field1,field2,field3) VALUES (?,?,?)"
@@ -81,7 +81,7 @@ func TestInsertBuilderSelect(t *testing.T) {
 	sb := Select("field1").From("table1").Where(Eq{"field1": 1})
 	ib := Insert("table2").Columns("field1").Select(sb)
 
-	sql, args, err := ib.ToSql()
+	sql, args, err := ib.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSQL := "INSERT INTO table2 (field1) SELECT field1 FROM table1 WHERE field1 = ?"

--- a/part.go
+++ b/part.go
@@ -14,12 +14,12 @@ func newPart(pred interface{}, args ...interface{}) Sqlizer {
 	return &part{pred, args}
 }
 
-func (p part) ToSql() (sql string, args []interface{}, err error) {
+func (p part) ToSQL() (sql string, args []interface{}, err error) {
 	switch pred := p.pred.(type) {
 	case nil:
 		// no-op
 	case Sqlizer:
-		sql, args, err = pred.ToSql()
+		sql, args, err = pred.ToSQL()
 	case string:
 		sql = pred
 		args = p.args
@@ -29,9 +29,9 @@ func (p part) ToSql() (sql string, args []interface{}, err error) {
 	return
 }
 
-func appendToSql(parts []Sqlizer, w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
+func appendToSQL(parts []Sqlizer, w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
 	for i, p := range parts {
-		partSql, partArgs, err := p.ToSql()
+		partSql, partArgs, err := p.ToSQL()
 		if err != nil {
 			return nil, err
 		} else if len(partSql) == 0 {

--- a/select.go
+++ b/select.go
@@ -51,7 +51,7 @@ func (d *selectData) QueryRow() RowScanner {
 	return QueryRowWith(queryRower, d)
 }
 
-func (d *selectData) ToSql() (sqlStr string, args []interface{}, err error) {
+func (d *selectData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	sqlStr, args, err = d.toSql()
 	if err != nil {
 		return
@@ -74,7 +74,7 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, _ = d.Prefixes.AppendToSQL(sql, " ", args)
 		sql.WriteString(" ")
 	}
 
@@ -86,7 +86,7 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 	}
 
 	if len(d.Columns) > 0 {
-		args, err = appendToSql(d.Columns, sql, ", ", args)
+		args, err = appendToSQL(d.Columns, sql, ", ", args)
 		if err != nil {
 			return
 		}
@@ -94,7 +94,7 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 
 	if d.From != nil {
 		sql.WriteString(" FROM ")
-		args, err = appendToSql([]Sqlizer{d.From}, sql, "", args)
+		args, err = appendToSQL([]Sqlizer{d.From}, sql, "", args)
 		if err != nil {
 			return
 		}
@@ -102,7 +102,7 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Joins) > 0 {
 		sql.WriteString(" ")
-		args, err = appendToSql(d.Joins, sql, " ", args)
+		args, err = appendToSQL(d.Joins, sql, " ", args)
 		if err != nil {
 			return
 		}
@@ -110,7 +110,7 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.WhereParts) > 0 {
 		sql.WriteString(" WHERE ")
-		args, err = appendToSql(d.WhereParts, sql, " AND ", args)
+		args, err = appendToSQL(d.WhereParts, sql, " AND ", args)
 		if err != nil {
 			return
 		}
@@ -123,7 +123,7 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.HavingParts) > 0 {
 		sql.WriteString(" HAVING ")
-		args, err = appendToSql(d.HavingParts, sql, " AND ", args)
+		args, err = appendToSQL(d.HavingParts, sql, " AND ", args)
 		if err != nil {
 			return
 		}
@@ -131,7 +131,7 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.OrderByParts) > 0 {
 		sql.WriteString(" ORDER BY ")
-		args, err = appendToSql(d.OrderByParts, sql, ", ", args)
+		args, err = appendToSQL(d.OrderByParts, sql, ", ", args)
 		if err != nil {
 			return
 		}
@@ -149,7 +149,7 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, _ = d.Suffixes.AppendToSQL(sql, " ", args)
 	}
 
 	sqlStr = sql.String()
@@ -205,14 +205,14 @@ func (b SelectBuilder) Scan(dest ...interface{}) error {
 
 // SQL methods
 
-// ToSql builds the query into a SQL string and bound args.
-func (b SelectBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b SelectBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(selectData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 func (b SelectBuilder) MustSql() (string, []interface{}) {
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	if err != nil {
 		panic(err)
 	}

--- a/squirrel.go
+++ b/squirrel.go
@@ -13,12 +13,12 @@ import (
 	"github.com/lann/builder"
 )
 
-// Sqlizer is the interface that wraps the ToSql method.
+// Sqlizer is the interface that wraps the ToSQL method.
 //
-// ToSql returns a SQL representation of the Sqlizer, along with a slice of args
+// ToSQL returns a SQL representation of the Sqlizer, along with a slice of args
 // as passed to e.g. database/sql.Exec. It can also return an error.
 type Sqlizer interface {
-	ToSql() (string, []interface{}, error)
+	ToSQL() (string, []interface{}, error)
 }
 
 // rawSqlizer is expected to do what Sqlizer does, but without finalizing placeholders.
@@ -98,7 +98,7 @@ var RunnerNotQueryRunner = fmt.Errorf("cannot QueryRow; Runner is not a QueryRow
 
 // ExecWith Execs the SQL returned by s with db.
 func ExecWith(db Execer, s Sqlizer) (res sql.Result, err error) {
-	query, args, err := s.ToSql()
+	query, args, err := s.ToSQL()
 	if err != nil {
 		return
 	}
@@ -107,7 +107,7 @@ func ExecWith(db Execer, s Sqlizer) (res sql.Result, err error) {
 
 // QueryWith Querys the SQL returned by s with db.
 func QueryWith(db Queryer, s Sqlizer) (rows *sql.Rows, err error) {
-	query, args, err := s.ToSql()
+	query, args, err := s.ToSQL()
 	if err != nil {
 		return
 	}
@@ -116,23 +116,23 @@ func QueryWith(db Queryer, s Sqlizer) (rows *sql.Rows, err error) {
 
 // QueryRowWith QueryRows the SQL returned by s with db.
 func QueryRowWith(db QueryRower, s Sqlizer) RowScanner {
-	query, args, err := s.ToSql()
+	query, args, err := s.ToSQL()
 	return &Row{RowScanner: db.QueryRow(query, args...), err: err}
 }
 
-// DebugSqlizer calls ToSql on s and shows the approximate SQL to be executed
+// DebugSqlizer calls ToSQL on s and shows the approximate SQL to be executed
 //
-// If ToSql returns an error, the result of this method will look like:
-// "[ToSql error: %s]" or "[DebugSqlizer error: %s]"
+// If ToSQL returns an error, the result of this method will look like:
+// "[ToSQL error: %s]" or "[DebugSqlizer error: %s]"
 //
 // IMPORTANT: As its name suggests, this function should only be used for
 // debugging. While the string result *might* be valid SQL, this function does
 // not try very hard to ensure it. Additionally, executing the output of this
 // function with any untrusted user input is certainly insecure.
 func DebugSqlizer(s Sqlizer) string {
-	sql, args, err := s.ToSql()
+	sql, args, err := s.ToSQL()
 	if err != nil {
-		return fmt.Sprintf("[ToSql error: %s]", err)
+		return fmt.Sprintf("[ToSQL error: %s]", err)
 	}
 
 	// TODO: dedupe this with placeholder.go

--- a/squirrel_ctx.go
+++ b/squirrel_ctx.go
@@ -38,7 +38,7 @@ func (r *stdsqlRunner) QueryRowContext(ctx context.Context, query string, args .
 
 // ExecContextWith ExecContexts the SQL returned by s with db.
 func ExecContextWith(ctx context.Context, db ExecerContext, s Sqlizer) (res sql.Result, err error) {
-	query, args, err := s.ToSql()
+	query, args, err := s.ToSQL()
 	if err != nil {
 		return
 	}
@@ -47,7 +47,7 @@ func ExecContextWith(ctx context.Context, db ExecerContext, s Sqlizer) (res sql.
 
 // QueryContextWith QueryContexts the SQL returned by s with db.
 func QueryContextWith(ctx context.Context, db QueryerContext, s Sqlizer) (rows *sql.Rows, err error) {
-	query, args, err := s.ToSql()
+	query, args, err := s.ToSQL()
 	if err != nil {
 		return
 	}
@@ -56,6 +56,6 @@ func QueryContextWith(ctx context.Context, db QueryerContext, s Sqlizer) (rows *
 
 // QueryRowContextWith QueryRowContexts the SQL returned by s with db.
 func QueryRowContextWith(ctx context.Context, db QueryRowerContext, s Sqlizer) RowScanner {
-	query, args, err := s.ToSql()
+	query, args, err := s.ToSQL()
 	return &Row{RowScanner: db.QueryRowContext(ctx, query, args...), err: err}
 }

--- a/squirrel_test.go
+++ b/squirrel_test.go
@@ -72,7 +72,7 @@ func TestQueryRowWith(t *testing.T) {
 	assert.Equal(t, sqlStr, db.LastQueryRowSql)
 }
 
-func TestWithToSqlErr(t *testing.T) {
+func TestWithToSQLErr(t *testing.T) {
 	db := &DBStub{}
 	sqlizer := Select()
 
@@ -100,5 +100,5 @@ func TestDebugSqlizerErrors(t *testing.T) {
 	assert.True(t, strings.HasPrefix(errorMsg, "[DebugSqlizer error: "))
 
 	errorMsg = DebugSqlizer(Lt{"x": nil}) // Cannot use nil values with Lt
-	assert.True(t, strings.HasPrefix(errorMsg, "[ToSql error: "))
+	assert.True(t, strings.HasPrefix(errorMsg, "[ToSQL error: "))
 }

--- a/update.go
+++ b/update.go
@@ -53,7 +53,7 @@ func (d *updateData) QueryRow() RowScanner {
 	return QueryRowWith(queryRower, d)
 }
 
-func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
+func (d *updateData) ToSQL() (sqlStr string, args []interface{}, err error) {
 	if len(d.Table) == 0 {
 		err = fmt.Errorf("update statements must specify a table")
 		return
@@ -66,7 +66,7 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, _ = d.Prefixes.AppendToSQL(sql, " ", args)
 		sql.WriteString(" ")
 	}
 
@@ -91,7 +91,7 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.WhereParts) > 0 {
 		sql.WriteString(" WHERE ")
-		args, err = appendToSql(d.WhereParts, sql, " AND ", args)
+		args, err = appendToSQL(d.WhereParts, sql, " AND ", args)
 		if err != nil {
 			return
 		}
@@ -114,7 +114,7 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, _ = d.Suffixes.AppendToSQL(sql, " ", args)
 	}
 
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
@@ -167,10 +167,10 @@ func (b UpdateBuilder) Scan(dest ...interface{}) error {
 
 // SQL methods
 
-// ToSql builds the query into a SQL string and bound args.
-func (b UpdateBuilder) ToSql() (string, []interface{}, error) {
+// ToSQL builds the query into a SQL string and bound args.
+func (b UpdateBuilder) ToSQL() (string, []interface{}, error) {
 	data := builder.GetStruct(b).(updateData)
-	return data.ToSql()
+	return data.ToSQL()
 }
 
 // Prefix adds an expression to the beginning of the query

--- a/update_test.go
+++ b/update_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpdateBuilderToSql(t *testing.T) {
+func TestUpdateBuilderToSQL(t *testing.T) {
 	b := Update("").
 		Prefix("WITH prefix AS ?", 0).
 		Table("a").
@@ -18,7 +18,7 @@ func TestUpdateBuilderToSql(t *testing.T) {
 		Offset(5).
 		Suffix("RETURNING ?", 6)
 
-	sql, args, err := b.ToSql()
+	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
 
 	expectedSql :=
@@ -32,21 +32,21 @@ func TestUpdateBuilderToSql(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestUpdateBuilderToSqlErr(t *testing.T) {
-	_, _, err := Update("").Set("x", 1).ToSql()
+func TestUpdateBuilderToSQLErr(t *testing.T) {
+	_, _, err := Update("").Set("x", 1).ToSQL()
 	assert.Error(t, err)
 
-	_, _, err = Update("x").ToSql()
+	_, _, err = Update("x").ToSQL()
 	assert.Error(t, err)
 }
 
 func TestUpdateBuilderPlaceholders(t *testing.T) {
 	b := Update("test").SetMap(Eq{"x": 1, "y": 2})
 
-	sql, _, _ := b.PlaceholderFormat(Question).ToSql()
+	sql, _, _ := b.PlaceholderFormat(Question).ToSQL()
 	assert.Equal(t, "UPDATE test SET x = ?, y = ?", sql)
 
-	sql, _, _ = b.PlaceholderFormat(Dollar).ToSql()
+	sql, _, _ = b.PlaceholderFormat(Dollar).ToSQL()
 	assert.Equal(t, "UPDATE test SET x = $1, y = $2", sql)
 }
 

--- a/where.go
+++ b/where.go
@@ -10,16 +10,16 @@ func newWherePart(pred interface{}, args ...interface{}) Sqlizer {
 	return &wherePart{pred: pred, args: args}
 }
 
-func (p wherePart) ToSql() (sql string, args []interface{}, err error) {
+func (p wherePart) ToSQL() (sql string, args []interface{}, err error) {
 	switch pred := p.pred.(type) {
 	case nil:
 		// no-op
 	case rawSqlizer:
 		return pred.toSqlRaw()
 	case Sqlizer:
-		return pred.ToSql()
+		return pred.ToSQL()
 	case map[string]interface{}:
-		return Eq(pred).ToSql()
+		return Eq(pred).ToSQL()
 	case string:
 		sql = pred
 		args = p.args

--- a/where_test.go
+++ b/where_test.go
@@ -8,43 +8,43 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWherePartsAppendToSql(t *testing.T) {
+func TestWherePartsAppendToSQL(t *testing.T) {
 	parts := []Sqlizer{
 		newWherePart("x = ?", 1),
 		newWherePart(nil),
 		newWherePart(Eq{"y": 2}),
 	}
 	sql := &bytes.Buffer{}
-	args, _ := appendToSql(parts, sql, " AND ", []interface{}{})
+	args, _ := appendToSQL(parts, sql, " AND ", []interface{}{})
 	assert.Equal(t, "x = ? AND y = ?", sql.String())
 	assert.Equal(t, []interface{}{1, 2}, args)
 }
 
-func TestWherePartsAppendToSqlErr(t *testing.T) {
+func TestWherePartsAppendToSQLErr(t *testing.T) {
 	parts := []Sqlizer{newWherePart(1)}
-	_, err := appendToSql(parts, &bytes.Buffer{}, "", []interface{}{})
+	_, err := appendToSQL(parts, &bytes.Buffer{}, "", []interface{}{})
 	assert.Error(t, err)
 }
 
 func TestWherePartNil(t *testing.T) {
-	sql, _, _ := newWherePart(nil).ToSql()
+	sql, _, _ := newWherePart(nil).ToSQL()
 	assert.Equal(t, "", sql)
 }
 
 func TestWherePartErr(t *testing.T) {
-	_, _, err := newWherePart(1).ToSql()
+	_, _, err := newWherePart(1).ToSQL()
 	assert.Error(t, err)
 }
 
 func TestWherePartString(t *testing.T) {
-	sql, args, _ := newWherePart("x = ?", 1).ToSql()
+	sql, args, _ := newWherePart("x = ?", 1).ToSQL()
 	assert.Equal(t, "x = ?", sql)
 	assert.Equal(t, []interface{}{1}, args)
 }
 
 func TestWherePartMap(t *testing.T) {
 	test := func(pred interface{}) {
-		sql, _, _ := newWherePart(pred).ToSql()
+		sql, _, _ := newWherePart(pred).ToSQL()
 		expect := []string{"x = ? AND y = ?", "y = ? AND x = ?"}
 		if sql != expect[0] && sql != expect[1] {
 			t.Errorf("expected one of %#v, got %#v", expect, sql)


### PR DESCRIPTION
Rename ToSql -> ToSQL

In some cases you want to implement squirrel.Sqlizer interface in your own project which fails by golint checks.