### PR TITLE
Expand Sqlizer arguments in Expr

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -365,3 +365,51 @@ func TestSqlLtOrder(t *testing.T) {
 	expectedArgs := []interface{}{1, 2, 3}
 	assert.Equal(t, expectedArgs, args)
 }
+
+func TestExprEscaped(t *testing.T) {
+	b := Expr("count(??)", Expr("x"))
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "count(??)"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{Expr("x")}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestExprRecursion(t *testing.T) {
+	{
+		b := Expr("count(?)", Expr("nullif(a,?)", "b"))
+		sql, args, err := b.ToSql()
+		assert.NoError(t, err)
+
+		expectedSql := "count(nullif(a,?))"
+		assert.Equal(t, expectedSql, sql)
+
+		expectedArgs := []interface{}{"b"}
+		assert.Equal(t, expectedArgs, args)
+	}
+	{
+		b := Expr("extract(? from ?)", Expr("epoch"), "2001-02-03")
+		sql, args, err := b.ToSql()
+		assert.NoError(t, err)
+
+		expectedSql := "extract(epoch from ?)"
+		assert.Equal(t, expectedSql, sql)
+
+		expectedArgs := []interface{}{"2001-02-03"}
+		assert.Equal(t, expectedArgs, args)
+	}
+	{
+		b := Expr("JOIN t1 ON ?", And{Eq{"id": 1}, Expr("NOT c1"), Expr("? @@ ?", "x", "y")})
+		sql, args, err := b.ToSql()
+		assert.NoError(t, err)
+
+		expectedSql := "JOIN t1 ON (id = ? AND NOT c1 AND ? @@ ?)"
+		assert.Equal(t, expectedSql, sql)
+
+		expectedArgs := []interface{}{1, "x", "y"}
+		assert.Equal(t, expectedArgs, args)
+	}
+}

--- a/insert.go
+++ b/insert.go
@@ -112,10 +112,13 @@ func (d *insertData) appendValuesToSQL(w io.Writer, args []interface{}) ([]inter
 	for r, row := range d.Values {
 		valueStrings := make([]string, len(row))
 		for v, val := range row {
-			e, isExpr := val.(expr)
-			if isExpr {
-				valueStrings[v] = e.sql
-				args = append(args, e.args...)
+			if vs, ok := val.(Sqlizer); ok {
+				vsql, vargs, err := vs.ToSql()
+				if err != nil {
+					return nil, err
+				}
+				valueStrings[v] = vsql
+				args = append(args, vargs...)
 			} else {
 				valueStrings[v] = "?"
 				args = append(args, val)

--- a/update.go
+++ b/update.go
@@ -77,17 +77,13 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 	setSqls := make([]string, len(d.SetClauses))
 	for i, setClause := range d.SetClauses {
 		var valSql string
-		e, isExpr := setClause.value.(expr)
-		if isExpr {
-			valSql = e.sql
-			args = append(args, e.args...)
-		} else if c, isCase := setClause.value.(CaseBuilder); isCase {
-			caseSql, caseArgs, err := c.ToSql()
+		if vs, ok := setClause.value.(Sqlizer); ok {
+			vsql, vargs, err := vs.ToSql()
 			if err != nil {
 				return "", nil, err
 			}
-			valSql = caseSql
-			args = append(args, caseArgs...)
+			valSql = vsql
+			args = append(args, vargs...)
 		} else {
 			valSql = "?"
 			args = append(args, setClause.value)


### PR DESCRIPTION
This allows one to include SQL in expression arguments and compose Sqlizers with custom SQL.