### PR TITLE
squirrel.DebugSqlizer: debug based on PlaceholderHolder (if present)

### DIFF
--- a/placeholder.go
+++ b/placeholder.go
@@ -12,61 +12,54 @@ import (
 // placeholder with a (possibly different) SQL placeholder.
 type PlaceholderFormat interface {
 	ReplacePlaceholders(sql string) (string, error)
-	PlaceholderHolder
 }
 
-type PlaceholderHolder interface {
-	GetPlaceholder() string
+type placeholderDebugger interface {
+	debugPlaceholder() string
 }
 
 var (
 	// Question is a PlaceholderFormat instance that leaves placeholders as
 	// question marks.
-	Question = questionFormat{"?"}
+	Question = questionFormat{}
 
 	// Dollar is a PlaceholderFormat instance that replaces placeholders with
 	// dollar-prefixed positional placeholders (e.g. $1, $2, $3).
-	Dollar = dollarFormat{"$"}
+	Dollar = dollarFormat{}
 
 	// Colon is a PlaceholderFormat instance that replaces placeholders with
 	// colon-prefixed positional placeholders (e.g. :1, :2, :3).
-	Colon = colonFormat{":"}
+	Colon = colonFormat{}
 )
 
-type questionFormat struct {
-	value string
-}
+type questionFormat struct{}
 
 func (questionFormat) ReplacePlaceholders(sql string) (string, error) {
 	return sql, nil
 }
 
-func (questionFormat) GetPlaceholder() string {
-	return Question.value
+func (questionFormat) debugPlaceholder() string {
+	return "?"
 }
 
-type dollarFormat struct {
-	value string
-}
+type dollarFormat struct{}
 
 func (dollarFormat) ReplacePlaceholders(sql string) (string, error) {
 	return replacePositionalPlaceholders(sql, "$")
 }
 
-func (dollarFormat) GetPlaceholder() string {
-	return Dollar.value
+func (dollarFormat) debugPlaceholder() string {
+	return "$"
 }
 
-type colonFormat struct {
-	value string
-}
+type colonFormat struct{}
 
 func (colonFormat) ReplacePlaceholders(sql string) (string, error) {
 	return replacePositionalPlaceholders(sql, ":")
 }
 
-func (colonFormat) GetPlaceholder() string {
-	return Colon.value
+func (colonFormat) debugPlaceholder() string {
+	return ":"
 }
 
 // Placeholders returns a string with count ? placeholders joined with commas.

--- a/placeholder.go
+++ b/placeholder.go
@@ -12,38 +12,61 @@ import (
 // placeholder with a (possibly different) SQL placeholder.
 type PlaceholderFormat interface {
 	ReplacePlaceholders(sql string) (string, error)
+	PlaceholderHolder
+}
+
+type PlaceholderHolder interface {
+	GetPlaceholder() string
 }
 
 var (
 	// Question is a PlaceholderFormat instance that leaves placeholders as
 	// question marks.
-	Question = questionFormat{}
+	Question = questionFormat{"?"}
 
 	// Dollar is a PlaceholderFormat instance that replaces placeholders with
 	// dollar-prefixed positional placeholders (e.g. $1, $2, $3).
-	Dollar = dollarFormat{}
+	Dollar = dollarFormat{"$"}
 
 	// Colon is a PlaceholderFormat instance that replaces placeholders with
 	// colon-prefixed positional placeholders (e.g. :1, :2, :3).
-	Colon = colonFormat{}
+	Colon = colonFormat{":"}
 )
 
-type questionFormat struct{}
+type questionFormat struct {
+	value string
+}
 
 func (questionFormat) ReplacePlaceholders(sql string) (string, error) {
 	return sql, nil
 }
 
-type dollarFormat struct{}
+func (questionFormat) GetPlaceholder() string {
+	return Question.value
+}
+
+type dollarFormat struct {
+	value string
+}
 
 func (dollarFormat) ReplacePlaceholders(sql string) (string, error) {
 	return replacePositionalPlaceholders(sql, "$")
 }
 
-type colonFormat struct{}
+func (dollarFormat) GetPlaceholder() string {
+	return Dollar.value
+}
+
+type colonFormat struct {
+	value string
+}
 
 func (colonFormat) ReplacePlaceholders(sql string) (string, error) {
 	return replacePositionalPlaceholders(sql, ":")
+}
+
+func (colonFormat) GetPlaceholder() string {
+	return Colon.value
 }
 
 // Placeholders returns a string with count ? placeholders joined with commas.

--- a/squirrel.go
+++ b/squirrel.go
@@ -136,11 +136,11 @@ func DebugSqlizer(s Sqlizer) string {
 	}
 
 	var placeholder string
-	downCast, ok := s.(PlaceholderHolder)
+	downCast, ok := s.(placeholderDebugger)
 	if !ok {
 		placeholder = "?"
 	} else {
-		placeholder = downCast.GetPlaceholder()
+		placeholder = downCast.debugPlaceholder()
 	}
 	// TODO: dedupe this with placeholder.go
 	buf := &bytes.Buffer{}

--- a/squirrel_test.go
+++ b/squirrel_test.go
@@ -86,6 +86,84 @@ func TestWithToSqlErr(t *testing.T) {
 	assert.Error(t, err)
 }
 
+var testDebugUpdateSQL = Update("table").SetMap(Eq{"x": 1, "y": "val"})
+var expectedDebugUpateSQL = "UPDATE table SET x = '1', y = 'val'"
+
+func TestDebugSqlizerUpdateColon(t *testing.T) {
+	testDebugUpdateSQL.PlaceholderFormat(Colon)
+	assert.Equal(t, expectedDebugUpateSQL, DebugSqlizer(testDebugUpdateSQL))
+}
+
+func TestDebugSqlizerUpdateDollar(t *testing.T) {
+	testDebugUpdateSQL.PlaceholderFormat(Dollar)
+	assert.Equal(t, expectedDebugUpateSQL, DebugSqlizer(testDebugUpdateSQL))
+}
+
+func TestDebugSqlizerUpdateQuestion(t *testing.T) {
+	testDebugUpdateSQL.PlaceholderFormat(Question)
+	assert.Equal(t, expectedDebugUpateSQL, DebugSqlizer(testDebugUpdateSQL))
+}
+
+var testDebugDeleteSQL = Delete("table").Where(And{
+	Eq{"column": "val"},
+	Eq{"other": 1},
+})
+var expectedDebugDeleteSQL = "DELETE FROM table WHERE (column = 'val' AND other = '1')"
+
+func TestDebugSqlizerDeleteColon(t *testing.T) {
+	testDebugDeleteSQL.PlaceholderFormat(Colon)
+	assert.Equal(t, expectedDebugDeleteSQL, DebugSqlizer(testDebugDeleteSQL))
+}
+
+func TestDebugSqlizerDeleteDollar(t *testing.T) {
+	testDebugDeleteSQL.PlaceholderFormat(Dollar)
+	assert.Equal(t, expectedDebugDeleteSQL, DebugSqlizer(testDebugDeleteSQL))
+}
+
+func TestDebugSqlizerDeleteQuestion(t *testing.T) {
+	testDebugDeleteSQL.PlaceholderFormat(Question)
+	assert.Equal(t, expectedDebugDeleteSQL, DebugSqlizer(testDebugDeleteSQL))
+}
+
+var testDebugInsertSQL = Insert("table").Values(1, "test")
+var expectedDebugInsertSQL = "INSERT INTO table VALUES ('1','test')"
+
+func TestDebugSqlizerInsertColon(t *testing.T) {
+	testDebugInsertSQL.PlaceholderFormat(Colon)
+	assert.Equal(t, expectedDebugInsertSQL, DebugSqlizer(testDebugInsertSQL))
+}
+
+func TestDebugSqlizerInsertDollar(t *testing.T) {
+	testDebugInsertSQL.PlaceholderFormat(Dollar)
+	assert.Equal(t, expectedDebugInsertSQL, DebugSqlizer(testDebugInsertSQL))
+}
+
+func TestDebugSqlizerInsertQuestion(t *testing.T) {
+	testDebugInsertSQL.PlaceholderFormat(Question)
+	assert.Equal(t, expectedDebugInsertSQL, DebugSqlizer(testDebugInsertSQL))
+}
+
+var testDebugSelectSQL = Select("*").From("table").Where(And{
+	Eq{"column": "val"},
+	Eq{"other": 1},
+})
+var expectedDebugSelectSQL = "SELECT * FROM table WHERE (column = 'val' AND other = '1')"
+
+func TestDebugSqlizerSelectColon(t *testing.T) {
+	testDebugSelectSQL.PlaceholderFormat(Colon)
+	assert.Equal(t, expectedDebugSelectSQL, DebugSqlizer(testDebugSelectSQL))
+}
+
+func TestDebugSqlizerSelectDollar(t *testing.T) {
+	testDebugSelectSQL.PlaceholderFormat(Dollar)
+	assert.Equal(t, expectedDebugSelectSQL, DebugSqlizer(testDebugSelectSQL))
+}
+
+func TestDebugSqlizerSelectQuestion(t *testing.T) {
+	testDebugSelectSQL.PlaceholderFormat(Question)
+	assert.Equal(t, expectedDebugSelectSQL, DebugSqlizer(testDebugSelectSQL))
+}
+
 func TestDebugSqlizer(t *testing.T) {
 	sqlizer := Expr("x = ? AND y = ? AND z = '??'", 1, "text")
 	expectedDebug := "x = '1' AND y = 'text' AND z = '?'"


### PR DESCRIPTION
References: https://github.com/Masterminds/squirrel/issues/116

In DebugSqlizer lets check if the provided `Sqlizer` has a `GetPlaceholder` method. If so, retrieve the placeholder, otherwise default to the existing behavior of debugging against `?`