### PR TITLE
Fix expression `LIMIT 0`

### DIFF
--- a/select.go
+++ b/select.go
@@ -137,12 +137,12 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 		}
 	}
 
-	if len(d.Limit) > 0 {
+	if len(d.Limit) > 0 && d.Limit != "0" {
 		sql.WriteString(" LIMIT ")
 		sql.WriteString(d.Limit)
 	}
 
-	if len(d.Offset) > 0 {
+	if len(d.Offset) > 0 && d.Offset != "0" {
 		sql.WriteString(" OFFSET ")
 		sql.WriteString(d.Offset)
 	}


### PR DESCRIPTION
Expression `LIMIT 0` is no use in SQL.
Value of `selectData.Limit` may be set to `"0"` as a result of integer defaults conversions.