### PR TITLE
Add support for function syntax

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -349,3 +349,38 @@ func isListType(val interface{}) bool {
 	valVal := reflect.ValueOf(val)
 	return valVal.Kind() == reflect.Array || valVal.Kind() == reflect.Slice
 }
+
+type fn struct {
+	name  string
+	fargs conj
+}
+
+func Fn(name string, args ...Sqlizer) *fn {
+	return &fn{name: name, fargs: args}
+}
+
+func (fn fn) ToSql() (sql string, args []interface{}, err error) {
+	var (
+		aSql  string
+		aArgs []interface{}
+	)
+
+	sql = fn.name + "("
+	args = make([]interface{}, 0)
+	for a := 0; a < len(fn.fargs); a++ {
+		if a > 0 {
+			sql += ", "
+		}
+
+		aSql, aArgs, err = fn.fargs[a].ToSql()
+		if err != nil {
+			return
+		}
+
+		sql += aSql
+		args = append(args, aArgs...)
+	}
+	sql += ")"
+
+	return
+}

--- a/expr_test.go
+++ b/expr_test.go
@@ -22,7 +22,7 @@ func TestEqToSql(t *testing.T) {
 func TestEqEmptyToSql(t *testing.T) {
 	sql, args, err := Eq{}.ToSql()
 	assert.NoError(t, err)
-	
+
 	expectedSql := "(1=1)"
 	assert.Equal(t, expectedSql, sql)
 	assert.Empty(t, args)
@@ -363,5 +363,28 @@ func TestSqlLtOrder(t *testing.T) {
 	assert.Equal(t, expectedSql, sql)
 
 	expectedArgs := []interface{}{1, 2, 3}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestFn(t *testing.T) {
+	b := Fn("IF", Expr("1 > 2"), Expr("2"), Expr("1"))
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "IF(1 > 2, 2, 1)"
+	assert.Equal(t, expectedSql, sql)
+
+	assert.Empty(t, args)
+}
+
+func TestFnWithArgs(t *testing.T) {
+	b := Fn("COALESCE", Expr("foo + ?", 42), Expr("?", 42))
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSql := "COALESCE(foo + ?, ?)"
+	assert.Equal(t, expectedSql, sql)
+
+	expectedArgs := []interface{}{42, 42}
 	assert.Equal(t, expectedArgs, args)
 }


### PR DESCRIPTION
`Fn("COALESCE", Expr("foo + ?", 42), Expr("?", 42))` produces `COALESCE(foo + ?, ?)` with `{42, 42}` args

I've tried to follow `Expr()` with naming, abbr. & func. signature.