### PR TITLE
Add the LimitSelect function to SelectBuilder

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -81,6 +81,26 @@ func (es exprs) AppendToSql(w io.Writer, sep string, args []interface{}) ([]inte
 	return args, nil
 }
 
+type parenExpr struct {
+	expr Sqlizer
+}
+
+// Parenthesized adds parentheses around the given expression
+//
+// Ex.
+//     Parenthesized(Select("*").From("foo)"))
+func Parenthesized(expr Sqlizer) parenExpr {
+	return parenExpr{expr: expr}
+}
+
+func (p parenExpr) ToSql() (sql string, args []interface{}, err error) {
+	sql, args, err = p.expr.ToSql()
+	if err == nil {
+		sql = fmt.Sprintf("(%s)", sql)
+	}
+	return
+}
+
 // aliasExpr helps to alias part of SQL query generated with underlying "expr"
 type aliasExpr struct {
 	expr  Sqlizer

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )
-
-go 1.13

--- a/select_test.go
+++ b/select_test.go
@@ -193,6 +193,20 @@ func TestSelectWithRemoveLimit(t *testing.T) {
 	assert.Equal(t, "SELECT * FROM foo", sql)
 }
 
+func TestSelectWithLimitSelect(t *testing.T) {
+	sql, _, err := Select("*").From("foo").LimitSelect(Select("1").From("bar")).ToSql()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT * FROM foo LIMIT (SELECT 1 FROM bar)", sql)
+}
+
+func TestSelectWithRemoveLimitSelect(t *testing.T) {
+	sql, _, err := Select("*").From("foo").LimitSelect(Select("1").From("bar")).RemoveLimit().ToSql()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT * FROM foo", sql)
+}
+
 func TestSelectWithRemoveOffset(t *testing.T) {
 	sql, _, err := Select("*").From("foo").Offset(10).RemoveOffset().ToSql()
 


### PR DESCRIPTION
In pgsql it is allowed to do a SELECT for a LIMIT, as follows:

```sql
SELECT * FROM foo
WHERE ...
LIMIT (SELECT col FROM bar)
```

This commit adds a function `LimitSelect, similar to the FromSelect function, that allows for
a SelectBuilder to be used for to create the limit clause.

This commit also adds a utility function `Parenthesized`, that simply returns a `Sqlizer` that
adds parentheses around the expression.