### PR TITLE
Add support for standard `database/sql` runners sans Context methods

### DIFF
--- a/squirrel.go
+++ b/squirrel.go
@@ -84,10 +84,10 @@ func (r *stdsqlRunner) QueryRow(query string, args ...interface{}) RowScanner {
 
 func setRunWith(b interface{}, runner BaseRunner) interface{} {
 	switch r := runner.(type) {
+	case StdSqlCtx:
+		runner = WrapStdSqlCtx(r)
 	case StdSql:
 		runner = WrapStdSql(r)
-	case StdSqlCtx:
-		runner = &stdsqlCtxRunner{r}
 	}
 	return builder.Set(b, "RunWith", runner)
 }

--- a/squirrel.go
+++ b/squirrel.go
@@ -5,7 +5,6 @@ package squirrel
 
 import (
 	"bytes"
-	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -63,11 +62,8 @@ type Runner interface {
 
 type stdsql interface {
 	Query(string, ...interface{}) (*sql.Rows, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
 	QueryRow(string, ...interface{}) *sql.Row
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 	Exec(string, ...interface{}) (sql.Result, error)
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 }
 
 type stdsqlRunner struct {
@@ -82,6 +78,8 @@ func setRunWith(b interface{}, runner BaseRunner) interface{} {
 	switch r := runner.(type) {
 	case stdsql:
 		runner = &stdsqlRunner{r}
+	case stdsqlCtx:
+		runner = &stdsqlCtxRunner{r}
 	}
 	return builder.Set(b, "RunWith", runner)
 }

--- a/squirrel_ctx.go
+++ b/squirrel_ctx.go
@@ -32,8 +32,25 @@ type QueryRowerContext interface {
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner
 }
 
-func (r *stdsqlRunner) QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner {
-	return r.stdsql.QueryRowContext(ctx, query, args...)
+type stdsqlCtx interface {
+	Query(string, ...interface{}) (*sql.Rows, error)
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+	QueryRow(string, ...interface{}) *sql.Row
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	Exec(string, ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+}
+
+type stdsqlCtxRunner struct {
+	stdsqlCtx
+}
+
+func (r *stdsqlCtxRunner) QueryRow(query string, args ...interface{}) RowScanner {
+	return r.stdsqlCtx.QueryRow(query, args...)
+}
+
+func (r *stdsqlCtxRunner) QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner {
+	return r.stdsqlCtx.QueryRowContext(ctx, query, args...)
 }
 
 // ExecContextWith ExecContexts the SQL returned by s with db.

--- a/squirrel_ctx.go
+++ b/squirrel_ctx.go
@@ -32,25 +32,40 @@ type QueryRowerContext interface {
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner
 }
 
-type stdsqlCtx interface {
-	Query(string, ...interface{}) (*sql.Rows, error)
+// RunnerContext groups the Runner interface, along with the Contect versions of each of
+// its methods
+type RunnerContext interface {
+	Runner
+	QueryerContext
+	QueryRowerContext
+	ExecerContext
+}
+
+// WrapStdSqlCtx wraps a type implementing the standard SQL interface plus the context
+// versions of the methods with methods that squirrel expects.
+func WrapStdSqlCtx(stdSqlCtx StdSqlCtx) RunnerContext {
+	return &stdsqlCtxRunner{stdSqlCtx}
+}
+
+// StdSqlCtx encompasses the standard methods of the *sql.DB type, along with the Context
+// versions of those methods, and other types that wrap these methods.
+type StdSqlCtx interface {
+	StdSql
 	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRow(string, ...interface{}) *sql.Row
 	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
-	Exec(string, ...interface{}) (sql.Result, error)
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 }
 
 type stdsqlCtxRunner struct {
-	stdsqlCtx
+	StdSqlCtx
 }
 
 func (r *stdsqlCtxRunner) QueryRow(query string, args ...interface{}) RowScanner {
-	return r.stdsqlCtx.QueryRow(query, args...)
+	return r.StdSqlCtx.QueryRow(query, args...)
 }
 
 func (r *stdsqlCtxRunner) QueryRowContext(ctx context.Context, query string, args ...interface{}) RowScanner {
-	return r.stdsqlCtx.QueryRowContext(ctx, query, args...)
+	return r.StdSqlCtx.QueryRowContext(ctx, query, args...)
 }
 
 // ExecContextWith ExecContexts the SQL returned by s with db.


### PR DESCRIPTION
## Summary

This PR adds support for use of the `.RunWith` method of various statement builders with a wrapper of the standard `database/sql` interface, minus the *Context methods, whilst maintaining support for the full standard `database/sql`. 

Furthermore, this adds methods for wrapping these standard `database/sql` wrappers so that they can be used with the `QueryRowWith(QueryRower, ...)` methods.