### PR TITLE
Add `PrefixExpr` and `SuffixExpr` methods to all builders

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -3,7 +3,6 @@ package squirrel
 import (
 	"database/sql/driver"
 	"fmt"
-	"io"
 	"reflect"
 	"sort"
 	"strings"
@@ -60,25 +59,6 @@ func (ce concatExpr) ToSql() (sql string, args []interface{}, err error) {
 //     ConcatExpr("COALESCE(full_name,", name_expr, ")")
 func ConcatExpr(parts ...interface{}) concatExpr {
 	return concatExpr(parts)
-}
-
-type exprs []expr
-
-func (es exprs) AppendToSql(w io.Writer, sep string, args []interface{}) ([]interface{}, error) {
-	for i, e := range es {
-		if i > 0 {
-			_, err := io.WriteString(w, sep)
-			if err != nil {
-				return nil, err
-			}
-		}
-		_, err := io.WriteString(w, e.sql)
-		if err != nil {
-			return nil, err
-		}
-		args = append(args, e.args...)
-	}
-	return args, nil
 }
 
 // aliasExpr helps to alias part of SQL query generated with underlying "expr"

--- a/insert.go
+++ b/insert.go
@@ -15,13 +15,13 @@ import (
 type insertData struct {
 	PlaceholderFormat PlaceholderFormat
 	RunWith           BaseRunner
-	Prefixes          exprs
+	Prefixes          []Sqlizer
 	StatementKeyword  string
 	Options           []string
 	Into              string
 	Columns           []string
 	Values            [][]interface{}
-	Suffixes          exprs
+	Suffixes          []Sqlizer
 	Select            *SelectBuilder
 }
 
@@ -63,7 +63,11 @@ func (d *insertData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, err = appendToSql(d.Prefixes, sql, " ", args)
+		if err != nil {
+			return
+		}
+
 		sql.WriteString(" ")
 	}
 
@@ -100,7 +104,10 @@ func (d *insertData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, err = appendToSql(d.Suffixes, sql, " ", args)
+		if err != nil {
+			return
+		}
 	}
 
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
@@ -208,7 +215,12 @@ func (b InsertBuilder) ToSql() (string, []interface{}, error) {
 
 // Prefix adds an expression to the beginning of the query
 func (b InsertBuilder) Prefix(sql string, args ...interface{}) InsertBuilder {
-	return builder.Append(b, "Prefixes", Expr(sql, args...)).(InsertBuilder)
+	return b.PrefixExpr(Expr(sql, args...))
+}
+
+// PrefixExpr adds an expression to the very beginning of the query
+func (b InsertBuilder) PrefixExpr(expr Sqlizer) InsertBuilder {
+	return builder.Append(b, "Prefixes", expr).(InsertBuilder)
 }
 
 // Options adds keyword options before the INTO clause of the query.
@@ -233,7 +245,12 @@ func (b InsertBuilder) Values(values ...interface{}) InsertBuilder {
 
 // Suffix adds an expression to the end of the query
 func (b InsertBuilder) Suffix(sql string, args ...interface{}) InsertBuilder {
-	return builder.Append(b, "Suffixes", Expr(sql, args...)).(InsertBuilder)
+	return b.SuffixExpr(Expr(sql, args...))
+}
+
+// SuffixExpr adds an expression to the end of the query
+func (b InsertBuilder) SuffixExpr(expr Sqlizer) InsertBuilder {
+	return builder.Append(b, "Suffixes", expr).(InsertBuilder)
 }
 
 // SetMap set columns and values for insert builder from a map of column name and value

--- a/update.go
+++ b/update.go
@@ -13,14 +13,14 @@ import (
 type updateData struct {
 	PlaceholderFormat PlaceholderFormat
 	RunWith           BaseRunner
-	Prefixes          exprs
+	Prefixes          []Sqlizer
 	Table             string
 	SetClauses        []setClause
 	WhereParts        []Sqlizer
 	OrderBys          []string
 	Limit             string
 	Offset            string
-	Suffixes          exprs
+	Suffixes          []Sqlizer
 }
 
 type setClause struct {
@@ -66,7 +66,11 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql := &bytes.Buffer{}
 
 	if len(d.Prefixes) > 0 {
-		args, _ = d.Prefixes.AppendToSql(sql, " ", args)
+		args, err = appendToSql(d.Prefixes, sql, " ", args)
+		if err != nil {
+			return
+		}
+
 		sql.WriteString(" ")
 	}
 
@@ -121,7 +125,10 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.Suffixes) > 0 {
 		sql.WriteString(" ")
-		args, _ = d.Suffixes.AppendToSql(sql, " ", args)
+		args, err = appendToSql(d.Suffixes, sql, " ", args)
+		if err != nil {
+			return
+		}
 	}
 
 	sqlStr, err = d.PlaceholderFormat.ReplacePlaceholders(sql.String())
@@ -182,7 +189,12 @@ func (b UpdateBuilder) ToSql() (string, []interface{}, error) {
 
 // Prefix adds an expression to the beginning of the query
 func (b UpdateBuilder) Prefix(sql string, args ...interface{}) UpdateBuilder {
-	return builder.Append(b, "Prefixes", Expr(sql, args...)).(UpdateBuilder)
+	return b.PrefixExpr(Expr(sql, args...))
+}
+
+// PrefixExpr adds an expression to the very beginning of the query
+func (b UpdateBuilder) PrefixExpr(expr Sqlizer) UpdateBuilder {
+	return builder.Append(b, "Prefixes", expr).(UpdateBuilder)
 }
 
 // Table sets the table to be updated.
@@ -235,5 +247,10 @@ func (b UpdateBuilder) Offset(offset uint64) UpdateBuilder {
 
 // Suffix adds an expression to the end of the query
 func (b UpdateBuilder) Suffix(sql string, args ...interface{}) UpdateBuilder {
-	return builder.Append(b, "Suffixes", Expr(sql, args...)).(UpdateBuilder)
+	return b.SuffixExpr(Expr(sql, args...))
+}
+
+// SuffixExpr adds an expression to the end of the query
+func (b UpdateBuilder) SuffixExpr(expr Sqlizer) UpdateBuilder {
+	return builder.Append(b, "Suffixes", expr).(UpdateBuilder)
 }


### PR DESCRIPTION
## Summary

This PR adds the `PrefixExpr(expr Sqlizer)` and `SuffixExpr(expr Sqlizer)` methods to all builders. 

This allows for more complex prefix expressions to be easily built in line, rather than having to create a seperate subquery builder, build the sql, and then use that as arguments to `.Prefix(sql, args...)`.

For example:

```go
sq.Select().
		PrefixExpr(sq.ConcatExpr(
			"WITH prefix AS (",
			sq.Select("foo").From("bar"),
			")"),
		).
		Columns("foo").
		From("prefix")
```