### PR TITLE
Have Expr() return an exported type

### DIFF
--- a/expr.go
+++ b/expr.go
@@ -24,7 +24,7 @@ type expr struct {
 //
 // Ex:
 //     Expr("FROM_UNIXTIME(?)", t)
-func Expr(sql string, args ...interface{}) expr {
+func Expr(sql string, args ...interface{}) Sqlizer {
 	return expr{sql: sql, args: args}
 }
 

--- a/expr.go
+++ b/expr.go
@@ -15,7 +15,7 @@ const (
 	sqlFalse = "(1=0)"
 )
 
-type Expression struct {
+type expr struct {
 	sql  string
 	args []interface{}
 }
@@ -24,11 +24,11 @@ type Expression struct {
 //
 // Ex:
 //     Expr("FROM_UNIXTIME(?)", t)
-func Expr(sql string, args ...interface{}) Expression {
-	return Expression{sql: sql, args: args}
+func Expr(sql string, args ...interface{}) expr {
+	return expr{sql: sql, args: args}
 }
 
-func (e Expression) ToSql() (sql string, args []interface{}, err error) {
+func (e expr) ToSql() (sql string, args []interface{}, err error) {
 	simple := true
 	for _, arg := range e.args {
 		if _, ok := arg.(Sqlizer); ok {

--- a/expr.go
+++ b/expr.go
@@ -15,7 +15,7 @@ const (
 	sqlFalse = "(1=0)"
 )
 
-type expr struct {
+type Expression struct {
 	sql  string
 	args []interface{}
 }
@@ -24,11 +24,11 @@ type expr struct {
 //
 // Ex:
 //     Expr("FROM_UNIXTIME(?)", t)
-func Expr(sql string, args ...interface{}) expr {
-	return expr{sql: sql, args: args}
+func Expr(sql string, args ...interface{}) Expression {
+	return Expression{sql: sql, args: args}
 }
 
-func (e expr) ToSql() (sql string, args []interface{}, err error) {
+func (e Expression) ToSql() (sql string, args []interface{}, err error) {
 	simple := true
 	for _, arg := range e.args {
 		if _, ok := arg.(Sqlizer); ok {


### PR DESCRIPTION
Type was not exported, making it impossible to compile for instance
```golang
offset := func(i int) squirrel.expr {
	return squirrel.Expr(fmt.Sprintf("select (now() at time zone 'utc') + interval '%d' nanosecond", i))
}
```
Note type `expr` was renamed to `Expression` as the `Expr` function is already public.

This does not break API compatibility.