### PR TITLE
MS SQL Server compatible placeholders

### DIFF
--- a/placeholder.go
+++ b/placeholder.go
@@ -73,7 +73,7 @@ func (atpFormat) ReplacePlaceholders(sql string) (string, error) {
 }
 
 func (atpFormat) debugPlaceholder() string {
-	return ":"
+	return "@p"
 }
 
 // Placeholders returns a string with count ? placeholders joined with commas.

--- a/placeholder.go
+++ b/placeholder.go
@@ -31,9 +31,9 @@ var (
 	// colon-prefixed positional placeholders (e.g. :1, :2, :3).
 	Colon = colonFormat{}
 
-	// Atp is a PlaceholderFormat instance that replaces placeholders with
+	// AtP is a PlaceholderFormat instance that replaces placeholders with
 	// "@p"-prefixed positional placeholders (e.g. @p1, @p2, @p3).
-	Atp = atpFormat{}
+	AtP = atpFormat{}
 )
 
 type questionFormat struct{}

--- a/placeholder.go
+++ b/placeholder.go
@@ -30,6 +30,10 @@ var (
 	// Colon is a PlaceholderFormat instance that replaces placeholders with
 	// colon-prefixed positional placeholders (e.g. :1, :2, :3).
 	Colon = colonFormat{}
+
+	// Atp is a PlaceholderFormat instance that replaces placeholders with
+	// "@p"-prefixed positional placeholders (e.g. @p1, @p2, @p3).
+	Atp = atpFormat{}
 )
 
 type questionFormat struct{}
@@ -59,6 +63,16 @@ func (colonFormat) ReplacePlaceholders(sql string) (string, error) {
 }
 
 func (colonFormat) debugPlaceholder() string {
+	return ":"
+}
+
+type atpFormat struct{}
+
+func (atpFormat) ReplacePlaceholders(sql string) (string, error) {
+	return replacePositionalPlaceholders(sql, "@p")
+}
+
+func (atpFormat) debugPlaceholder() string {
 	return ":"
 }
 

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -25,6 +25,12 @@ func TestColon(t *testing.T) {
 	assert.Equal(t, "x = :1 AND y = :2", s)
 }
 
+func TestAtp(t *testing.T) {
+	sql := "x = ? AND y = ?"
+	s, _ := Atp.ReplacePlaceholders(sql)
+	assert.Equal(t, "x = @p1 AND y = @p2", s)
+}
+
 func TestPlaceholders(t *testing.T) {
 	assert.Equal(t, Placeholders(2), "?,?")
 }
@@ -39,6 +45,12 @@ func TestEscapeColon(t *testing.T) {
 	sql := "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ??| array['?'] AND enabled = ?"
 	s, _ := Colon.ReplacePlaceholders(sql)
 	assert.Equal(t, "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ?| array[':1'] AND enabled = :2", s)
+}
+
+func TestEscapeAtp(t *testing.T) {
+	sql := "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ??| array['?'] AND enabled = ?"
+	s, _ := Atp.ReplacePlaceholders(sql)
+	assert.Equal(t, "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ?| array['@p1'] AND enabled = @p2", s)
 }
 
 func BenchmarkPlaceholdersArray(b *testing.B) {

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -27,7 +27,7 @@ func TestColon(t *testing.T) {
 
 func TestAtp(t *testing.T) {
 	sql := "x = ? AND y = ?"
-	s, _ := Atp.ReplacePlaceholders(sql)
+	s, _ := AtP.ReplacePlaceholders(sql)
 	assert.Equal(t, "x = @p1 AND y = @p2", s)
 }
 
@@ -49,7 +49,7 @@ func TestEscapeColon(t *testing.T) {
 
 func TestEscapeAtp(t *testing.T) {
 	sql := "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ??| array['?'] AND enabled = ?"
-	s, _ := Atp.ReplacePlaceholders(sql)
+	s, _ := AtP.ReplacePlaceholders(sql)
 	assert.Equal(t, "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ?| array['@p1'] AND enabled = @p2", s)
 }
 

--- a/select_test.go
+++ b/select_test.go
@@ -101,6 +101,9 @@ func TestSelectBuilderPlaceholders(t *testing.T) {
 
 	sql, _, _ = b.PlaceholderFormat(Colon).ToSql()
 	assert.Equal(t, "SELECT test WHERE x = :1 AND y = :2", sql)
+
+	sql, _, _ = b.PlaceholderFormat(Atp).ToSql()
+	assert.Equal(t, "SELECT test WHERE x = @p1 AND y = @p2", sql)
 }
 
 func TestSelectBuilderRunners(t *testing.T) {

--- a/select_test.go
+++ b/select_test.go
@@ -102,7 +102,7 @@ func TestSelectBuilderPlaceholders(t *testing.T) {
 	sql, _, _ = b.PlaceholderFormat(Colon).ToSql()
 	assert.Equal(t, "SELECT test WHERE x = :1 AND y = :2", sql)
 
-	sql, _, _ = b.PlaceholderFormat(Atp).ToSql()
+	sql, _, _ = b.PlaceholderFormat(AtP).ToSql()
 	assert.Equal(t, "SELECT test WHERE x = @p1 AND y = @p2", sql)
 }
 

--- a/squirrel_test.go
+++ b/squirrel_test.go
@@ -95,7 +95,7 @@ func TestDebugSqlizerUpdateColon(t *testing.T) {
 }
 
 func TestDebugSqlizerUpdateAtp(t *testing.T) {
-	testDebugUpdateSQL.PlaceholderFormat(Atp)
+	testDebugUpdateSQL.PlaceholderFormat(AtP)
 	assert.Equal(t, expectedDebugUpateSQL, DebugSqlizer(testDebugUpdateSQL))
 }
 
@@ -121,7 +121,7 @@ func TestDebugSqlizerDeleteColon(t *testing.T) {
 }
 
 func TestDebugSqlizerDeleteAtp(t *testing.T) {
-	testDebugDeleteSQL.PlaceholderFormat(Atp)
+	testDebugDeleteSQL.PlaceholderFormat(AtP)
 	assert.Equal(t, expectedDebugDeleteSQL, DebugSqlizer(testDebugDeleteSQL))
 }
 
@@ -144,7 +144,7 @@ func TestDebugSqlizerInsertColon(t *testing.T) {
 }
 
 func TestDebugSqlizerInsertAtp(t *testing.T) {
-	testDebugInsertSQL.PlaceholderFormat(Atp)
+	testDebugInsertSQL.PlaceholderFormat(AtP)
 	assert.Equal(t, expectedDebugInsertSQL, DebugSqlizer(testDebugInsertSQL))
 }
 
@@ -170,7 +170,7 @@ func TestDebugSqlizerSelectColon(t *testing.T) {
 }
 
 func TestDebugSqlizerSelectAtp(t *testing.T) {
-	testDebugSelectSQL.PlaceholderFormat(Atp)
+	testDebugSelectSQL.PlaceholderFormat(AtP)
 	assert.Equal(t, expectedDebugSelectSQL, DebugSqlizer(testDebugSelectSQL))
 }
 

--- a/squirrel_test.go
+++ b/squirrel_test.go
@@ -94,6 +94,11 @@ func TestDebugSqlizerUpdateColon(t *testing.T) {
 	assert.Equal(t, expectedDebugUpateSQL, DebugSqlizer(testDebugUpdateSQL))
 }
 
+func TestDebugSqlizerUpdateAtp(t *testing.T) {
+	testDebugUpdateSQL.PlaceholderFormat(Atp)
+	assert.Equal(t, expectedDebugUpateSQL, DebugSqlizer(testDebugUpdateSQL))
+}
+
 func TestDebugSqlizerUpdateDollar(t *testing.T) {
 	testDebugUpdateSQL.PlaceholderFormat(Dollar)
 	assert.Equal(t, expectedDebugUpateSQL, DebugSqlizer(testDebugUpdateSQL))
@@ -115,6 +120,11 @@ func TestDebugSqlizerDeleteColon(t *testing.T) {
 	assert.Equal(t, expectedDebugDeleteSQL, DebugSqlizer(testDebugDeleteSQL))
 }
 
+func TestDebugSqlizerDeleteAtp(t *testing.T) {
+	testDebugDeleteSQL.PlaceholderFormat(Atp)
+	assert.Equal(t, expectedDebugDeleteSQL, DebugSqlizer(testDebugDeleteSQL))
+}
+
 func TestDebugSqlizerDeleteDollar(t *testing.T) {
 	testDebugDeleteSQL.PlaceholderFormat(Dollar)
 	assert.Equal(t, expectedDebugDeleteSQL, DebugSqlizer(testDebugDeleteSQL))
@@ -130,6 +140,11 @@ var expectedDebugInsertSQL = "INSERT INTO table VALUES ('1','test')"
 
 func TestDebugSqlizerInsertColon(t *testing.T) {
 	testDebugInsertSQL.PlaceholderFormat(Colon)
+	assert.Equal(t, expectedDebugInsertSQL, DebugSqlizer(testDebugInsertSQL))
+}
+
+func TestDebugSqlizerInsertAtp(t *testing.T) {
+	testDebugInsertSQL.PlaceholderFormat(Atp)
 	assert.Equal(t, expectedDebugInsertSQL, DebugSqlizer(testDebugInsertSQL))
 }
 
@@ -151,6 +166,11 @@ var expectedDebugSelectSQL = "SELECT * FROM table WHERE (column = 'val' AND othe
 
 func TestDebugSqlizerSelectColon(t *testing.T) {
 	testDebugSelectSQL.PlaceholderFormat(Colon)
+	assert.Equal(t, expectedDebugSelectSQL, DebugSqlizer(testDebugSelectSQL))
+}
+
+func TestDebugSqlizerSelectAtp(t *testing.T) {
+	testDebugSelectSQL.PlaceholderFormat(Atp)
 	assert.Equal(t, expectedDebugSelectSQL, DebugSqlizer(testDebugSelectSQL))
 }
 


### PR DESCRIPTION
Added at placeholders (@p1) syntax. This usable with MS SQL Server.
Without this feature impossible to use squirrel with SQL Server.