### PR TITLE
TestSelectBuilderToSql fixed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/Masterminds/squirrel
 
+go 1.14
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0

--- a/select_test.go
+++ b/select_test.go
@@ -49,7 +49,7 @@ func TestSelectBuilderToSql(t *testing.T) {
 			"(b IN (?,?,?)) AS b_alias, " +
 			"(SELECT aa, bb FROM dd) AS subq " +
 			"FROM e " +
-			"CROSS JOIN j1 JOIN j2 LEFT JOIN j3 RIGHT JOIN j4 INNER JOIN j5 CROSS JOIN j6" +
+			"CROSS JOIN j1 JOIN j2 LEFT JOIN j3 RIGHT JOIN j4 INNER JOIN j5 CROSS JOIN j6 " +
 			"WHERE f = ? AND g = ? AND h = ? AND i IN (?,?,?) AND (j = ? OR (k = ? AND true)) " +
 			"GROUP BY l HAVING m = n ORDER BY ? DESC, o ASC, p DESC LIMIT 12 OFFSET 13 " +
 			"FETCH FIRST ? ROWS ONLY"


### PR DESCRIPTION
## Problem
The test `TestSelectBuilderToSql` fails because the expected string contains `"CROSS JOIN j6WHERE"` instead of `"CROSS JOIN j6 WHERE"`

##Solution
The expected string contains `"CROSS JOIN j6 WHERE"`