### PR TITLE
Add missing MustSql methods

### DIFF
--- a/case.go
+++ b/case.go
@@ -100,6 +100,16 @@ func (b CaseBuilder) ToSql() (string, []interface{}, error) {
 	return data.ToSql()
 }
 
+// MustSql builds the query into a SQL string and bound args.
+// It panics if there are any errors.
+func (b CaseBuilder) MustSql() (string, []interface{}) {
+	sql, args, err := b.ToSql()
+	if err != nil {
+		panic(err)
+	}
+	return sql, args
+}
+
 // what sets optional value for CASE construct "CASE [value] ..."
 func (b CaseBuilder) what(expr interface{}) CaseBuilder {
 	return builder.Set(b, "What", newPart(expr)).(CaseBuilder)

--- a/case_test.go
+++ b/case_test.go
@@ -139,3 +139,12 @@ func TestCaseWithNoWhenClause(t *testing.T) {
 
 	assert.Equal(t, "case expression must contain at lease one WHEN clause", err.Error())
 }
+
+func TestCaseBuilderMustSql(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("TestCaseBuilderMustSql should have panicked!")
+		}
+	}()
+	Case("").MustSql()
+}

--- a/delete.go
+++ b/delete.go
@@ -121,6 +121,16 @@ func (b DeleteBuilder) ToSql() (string, []interface{}, error) {
 	return data.ToSql()
 }
 
+// MustSql builds the query into a SQL string and bound args.
+// It panics if there are any errors.
+func (b DeleteBuilder) MustSql() (string, []interface{}) {
+	sql, args, err := b.ToSql()
+	if err != nil {
+		panic(err)
+	}
+	return sql, args
+}
+
 // Prefix adds an expression to the beginning of the query
 func (b DeleteBuilder) Prefix(sql string, args ...interface{}) DeleteBuilder {
 	return b.PrefixExpr(Expr(sql, args...))

--- a/delete_test.go
+++ b/delete_test.go
@@ -34,6 +34,15 @@ func TestDeleteBuilderToSqlErr(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDeleteBuilderMustSql(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("TestDeleteBuilderMustSql should have panicked!")
+		}
+	}()
+	Delete("").MustSql()
+}
+
 func TestDeleteBuilderPlaceholders(t *testing.T) {
 	b := Delete("test").Where("x = ? AND y = ?", 1, 2)
 

--- a/insert.go
+++ b/insert.go
@@ -216,6 +216,16 @@ func (b InsertBuilder) ToSql() (string, []interface{}, error) {
 	return data.ToSql()
 }
 
+// MustSql builds the query into a SQL string and bound args.
+// It panics if there are any errors.
+func (b InsertBuilder) MustSql() (string, []interface{}) {
+	sql, args, err := b.ToSql()
+	if err != nil {
+		panic(err)
+	}
+	return sql, args
+}
+
 // Prefix adds an expression to the beginning of the query
 func (b InsertBuilder) Prefix(sql string, args ...interface{}) InsertBuilder {
 	return b.PrefixExpr(Expr(sql, args...))

--- a/insert_test.go
+++ b/insert_test.go
@@ -37,6 +37,15 @@ func TestInsertBuilderToSqlErr(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestInsertBuilderMustSql(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("TestInsertBuilderMustSql should have panicked!")
+		}
+	}()
+	Insert("").MustSql()
+}
+
 func TestInsertBuilderPlaceholders(t *testing.T) {
 	b := Insert("test").Values(1, 2)
 

--- a/select.go
+++ b/select.go
@@ -222,6 +222,8 @@ func (b SelectBuilder) ToSql() (string, []interface{}, error) {
 	return data.ToSql()
 }
 
+// MustSql builds the query into a SQL string and bound args.
+// It panics if there are any errors.
 func (b SelectBuilder) MustSql() (string, []interface{}) {
 	sql, args, err := b.ToSql()
 	if err != nil {

--- a/select_test.go
+++ b/select_test.go
@@ -219,16 +219,14 @@ func TestSelectBuilderNestedSelectDollar(t *testing.T) {
 	assert.Equal(t, "SELECT * FROM foo WHERE x = $1 AND NOT EXISTS ( SELECT * FROM bar WHERE y = $2 )", outerSql)
 }
 
-func TestMustSql(t *testing.T) {
-	func() {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("TestUserFail should have panicked!")
-			}
-		}()
-		// This function should cause a panic
-		Select().From("foo").MustSql()
+func TestSelectBuilderMustSql(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("TestSelectBuilderMustSql should have panicked!")
+		}
 	}()
+	// This function should cause a panic
+	Select().From("foo").MustSql()
 }
 
 func TestSelectWithoutWhereClause(t *testing.T) {

--- a/update.go
+++ b/update.go
@@ -187,6 +187,16 @@ func (b UpdateBuilder) ToSql() (string, []interface{}, error) {
 	return data.ToSql()
 }
 
+// MustSql builds the query into a SQL string and bound args.
+// It panics if there are any errors.
+func (b UpdateBuilder) MustSql() (string, []interface{}) {
+	sql, args, err := b.ToSql()
+	if err != nil {
+		panic(err)
+	}
+	return sql, args
+}
+
 // Prefix adds an expression to the beginning of the query
 func (b UpdateBuilder) Prefix(sql string, args ...interface{}) UpdateBuilder {
 	return b.PrefixExpr(Expr(sql, args...))

--- a/update_test.go
+++ b/update_test.go
@@ -47,6 +47,15 @@ func TestUpdateBuilderToSqlErr(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestUpdateBuilderMustSql(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("TestUpdateBuilderMustSql should have panicked!")
+		}
+	}()
+	Update("").MustSql()
+}
+
 func TestUpdateBuilderPlaceholders(t *testing.T) {
 	b := Update("test").SetMap(Eq{"x": 1, "y": 2})
 


### PR DESCRIPTION
`MustSql()` method on `SelectBuilder` tends to be quite useful when working with less dynamic queries, however, at the moment, it's not possible to have the same flow with queries made with `CaseBuilder`, `DeleteBuilder`, `InsertBuilder` and `UpdateBuilder`. This PR adds `MustSql()` method to all of them.

Related PR: https://github.com/Masterminds/squirrel/pull/156