### PR TITLE
Optimize allocation

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,164 @@
+// from https://github.com/elgris/golang-sql-builder-benchmark/blob/master/squirrel_benchmark_test.go
+
+package squirrel_test
+
+import (
+	"testing"
+
+	"github.com/Masterminds/squirrel"
+)
+
+func BenchmarkSquirrelSelectSimple(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		squirrel.Select("id").
+			From("tickets").
+			Where("subdomain_id = ? and (state = ? or state = ?)", 1, "open", "spam").
+			ToSql()
+	}
+}
+
+func BenchmarkSquirrelSelectConditional(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		qb := squirrel.Select("id").
+			From("tickets").
+			Where("subdomain_id = ? and (state = ? or state = ?)", 1, "open", "spam")
+
+		if n%2 == 0 {
+			qb = qb.GroupBy("subdomain_id").
+				Having("number = ?", 1).
+				OrderBy("state").
+				Limit(7).
+				Offset(8)
+		}
+
+		qb.ToSql()
+	}
+}
+
+func BenchmarkSquirrelSelectComplex(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		squirrel.Select("a", "b", "z", "y", "x").
+			Distinct().
+			From("c").
+			Where("d = ? OR e = ?", 1, "wat").
+			Where(squirrel.Eq{"f": 2, "x": "hi"}).
+			Where(map[string]interface{}{"g": 3}).
+			Where(squirrel.Eq{"h": []int{1, 2, 3}}).
+			GroupBy("i").
+			GroupBy("ii").
+			GroupBy("iii").
+			Having("j = k").
+			Having("jj = ?", 1).
+			Having("jjj = ?", 2).
+			OrderBy("l").
+			OrderBy("l").
+			OrderBy("l").
+			Limit(7).
+			Offset(8).
+			ToSql()
+	}
+}
+
+func BenchmarkSquirrelSelectSubquery(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		subSelect := squirrel.Select("id").
+			From("tickets").
+			Where("subdomain_id = ? and (state = ? or state = ?)", 1, "open", "spam")
+
+		squirrel.Select("a", "b").
+			From("c").
+			Distinct().
+			Column(squirrel.Alias(subSelect, "subq")).
+			Where(squirrel.Eq{"f": 2, "x": "hi"}).
+			Where(map[string]interface{}{"g": 3}).
+			OrderBy("l").
+			OrderBy("l").
+			Limit(7).
+			Offset(8).
+			ToSql()
+
+	}
+}
+
+func BenchmarkSquirrelSelectMoreComplex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+
+		squirrel.Select("a", "b").
+			Prefix("WITH prefix AS ?", 0).
+			Distinct().
+			Columns("c").
+			Column("IF(d IN ("+squirrel.Placeholders(3)+"), 1, 0) as stat_column", 1, 2, 3).
+			Column(squirrel.Expr("a > ?", 100)).
+			Column(squirrel.Eq{"b": []int{101, 102, 103}}).
+			From("e").
+			JoinClause("CROSS JOIN j1").
+			Join("j2").
+			LeftJoin("j3").
+			RightJoin("j4").
+			Where("f = ?", 4).
+			Where(squirrel.Eq{"g": 5}).
+			Where(map[string]interface{}{"h": 6}).
+			Where(squirrel.Eq{"i": []int{7, 8, 9}}).
+			Where(squirrel.Or{squirrel.Expr("j = ?", 10), squirrel.And{squirrel.Eq{"k": 11}, squirrel.Expr("true")}}).
+			GroupBy("l").
+			Having("m = n").
+			OrderBy("o ASC", "p DESC").
+			Limit(12).
+			Offset(13).
+			Suffix("FETCH FIRST ? ROWS ONLY", 14).
+			ToSql()
+	}
+}
+
+//
+// Insert benchmark
+//
+func BenchmarkSquirrelInsert(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		squirrel.Insert("mytable").
+			Columns("id", "a", "b", "price", "created", "updated").
+			Values(1, "test_a", "test_b", 100.05, "2014-01-05", "2015-01-05").
+			ToSql()
+	}
+}
+
+//
+// Update benchmark
+//
+func BenchmarkSquirrelUpdateSetColumns(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		squirrel.Update("mytable").
+			Set("foo", 1).
+			Set("bar", squirrel.Expr("COALESCE(bar, 0) + 1")).
+			Set("c", 2).
+			Where("id = ?", 9).
+			Limit(10).
+			Offset(20).
+			ToSql()
+	}
+}
+
+func BenchmarkSquirrelUpdateSetMap(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		squirrel.Update("mytable").
+			SetMap(map[string]interface{}{"b": 1, "c": 2, "bar": squirrel.Expr("COALESCE(bar, 0) + 1")}).
+			Where("id = ?", 9).
+			Limit(10).
+			Offset(20).
+			ToSql()
+	}
+}
+
+//
+// Delete benchmark
+//
+func BenchmarkSquirrelDelete(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		squirrel.Delete("test_table").
+			Where("b = ?", 1).
+			OrderBy("c").
+			Limit(2).
+			Offset(3).
+			ToSql()
+	}
+}

--- a/delete.go
+++ b/delete.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"strings"
+	"strconv"
 
 	"github.com/lann/builder"
 )
@@ -58,7 +58,11 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.OrderBys) > 0 {
 		sql.WriteString(" ORDER BY ")
-		sql.WriteString(strings.Join(d.OrderBys, ", "))
+		sql.WriteString(d.OrderBys[0])
+		for _, ob := range d.OrderBys[1:] {
+			sql.WriteString(", ")
+			sql.WriteString(ob)
+		}
 	}
 
 	if len(d.Limit) > 0 {
@@ -160,12 +164,12 @@ func (b DeleteBuilder) OrderBy(orderBys ...string) DeleteBuilder {
 
 // Limit sets a LIMIT clause on the query.
 func (b DeleteBuilder) Limit(limit uint64) DeleteBuilder {
-	return builder.Set(b, "Limit", fmt.Sprintf("%d", limit)).(DeleteBuilder)
+	return builder.Set(b, "Limit", strconv.FormatUint(limit, 10)).(DeleteBuilder)
 }
 
 // Offset sets a OFFSET clause on the query.
 func (b DeleteBuilder) Offset(offset uint64) DeleteBuilder {
-	return builder.Set(b, "Offset", fmt.Sprintf("%d", offset)).(DeleteBuilder)
+	return builder.Set(b, "Offset", strconv.FormatUint(offset, 10)).(DeleteBuilder)
 }
 
 // Suffix adds an expression to the end of the query

--- a/placeholder.go
+++ b/placeholder.go
@@ -2,7 +2,7 @@ package squirrel
 
 import (
 	"bytes"
-	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -104,7 +104,7 @@ func replacePositionalPlaceholders(sql, prefix string) (string, error) {
 		} else {
 			i++
 			buf.WriteString(sql[:p])
-			fmt.Fprintf(buf, "%s%d", prefix, i)
+			buf.WriteString(prefix + strconv.Itoa(i))
 			sql = sql[p+1:]
 		}
 	}

--- a/select.go
+++ b/select.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"strings"
+	"strconv"
 
 	"github.com/lann/builder"
 )
@@ -85,7 +85,11 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 	sql.WriteString("SELECT ")
 
 	if len(d.Options) > 0 {
-		sql.WriteString(strings.Join(d.Options, " "))
+		sql.WriteString(d.Options[0])
+		for _, o := range d.Options[1:] {
+			sql.WriteString(" ")
+			sql.WriteString(o)
+		}
 		sql.WriteString(" ")
 	}
 
@@ -122,7 +126,11 @@ func (d *selectData) toSql() (sqlStr string, args []interface{}, err error) {
 
 	if len(d.GroupBys) > 0 {
 		sql.WriteString(" GROUP BY ")
-		sql.WriteString(strings.Join(d.GroupBys, ", "))
+		sql.WriteString(d.GroupBys[0])
+		for _, gb := range d.GroupBys[1:] {
+			sql.WriteString(", ")
+			sql.WriteString(gb)
+		}
 	}
 
 	if len(d.HavingParts) > 0 {
@@ -371,7 +379,7 @@ func (b SelectBuilder) OrderBy(orderBys ...string) SelectBuilder {
 
 // Limit sets a LIMIT clause on the query.
 func (b SelectBuilder) Limit(limit uint64) SelectBuilder {
-	return builder.Set(b, "Limit", fmt.Sprintf("%d", limit)).(SelectBuilder)
+	return builder.Set(b, "Limit", strconv.FormatUint(limit, 10)).(SelectBuilder)
 }
 
 // Limit ALL allows to access all records with limit
@@ -381,7 +389,7 @@ func (b SelectBuilder) RemoveLimit() SelectBuilder {
 
 // Offset sets a OFFSET clause on the query.
 func (b SelectBuilder) Offset(offset uint64) SelectBuilder {
-	return builder.Set(b, "Offset", fmt.Sprintf("%d", offset)).(SelectBuilder)
+	return builder.Set(b, "Offset", strconv.FormatUint(offset, 10)).(SelectBuilder)
 }
 
 // RemoveOffset removes OFFSET clause.


### PR DESCRIPTION
- Avoid using fmt.Sprintf
- Avoid allocating intermediate slices
- Write directly to the buffer during iterating instead of strings.Join

before
```
goos: linux
goarch: amd64
pkg: github.com/Masterminds/squirrel
cpu: 11th Gen Intel(R) Core(TM) i3-1115G4 @ 3.00GHz
BenchmarkPlaceholdersArray-4            58258798                17.99 ns/op           18 B/op          0 allocs/op
BenchmarkPlaceholdersStrings-4          1000000000               0.4272 ns/op          2 B/op          0 allocs/op
BenchmarkSquirrelSelectSimple-4           335403              3482 ns/op            2472 B/op         49 allocs/op
BenchmarkSquirrelSelectConditional-4      218160              5563 ns/op            3708 B/op         78 allocs/op
BenchmarkSquirrelSelectComplex-4           63566             19078 ns/op           12362 B/op        275 allocs/op
BenchmarkSquirrelSelectSubquery-4          82434             15066 ns/op            9577 B/op        205 allocs/op
BenchmarkSquirrelSelectMoreComplex-4       46256             25689 ns/op           17218 B/op        391 allocs/op
BenchmarkSquirrelInsert-4                 292023              4127 ns/op            3016 B/op         67 allocs/op
BenchmarkSquirrelUpdateSetColumns-4       183298              6639 ns/op            4376 B/op        101 allocs/op
BenchmarkSquirrelUpdateSetMap-4           173980              6824 ns/op            4448 B/op        103 allocs/op
BenchmarkSquirrelDelete-4                 289329              4167 ns/op            2536 B/op         61 allocs/op
PASS
ok      github.com/Masterminds/squirrel 14.236s
```

after
```
goos: linux
goarch: amd64
pkg: github.com/Masterminds/squirrel
cpu: 11th Gen Intel(R) Core(TM) i3-1115G4 @ 3.00GHz
BenchmarkPlaceholdersArray-4            93750074                11.69 ns/op           18 B/op          0 allocs/op
BenchmarkPlaceholdersStrings-4          1000000000               0.3634 ns/op          2 B/op          0 allocs/op
BenchmarkSquirrelSelectSimple-4           348493              3390 ns/op            2472 B/op         49 allocs/op
BenchmarkSquirrelSelectConditional-4      222134              5405 ns/op            3708 B/op         78 allocs/op
BenchmarkSquirrelSelectComplex-4           67896             17862 ns/op           12120 B/op        260 allocs/op
BenchmarkSquirrelSelectSubquery-4          87997             13688 ns/op            9384 B/op        193 allocs/op
BenchmarkSquirrelSelectMoreComplex-4       49639             24260 ns/op           16800 B/op        367 allocs/op
BenchmarkSquirrelInsert-4                 307369              3925 ns/op            2824 B/op         61 allocs/op
BenchmarkSquirrelUpdateSetColumns-4       202728              5952 ns/op            4136 B/op         88 allocs/op
BenchmarkSquirrelUpdateSetMap-4           195135              6164 ns/op            4208 B/op         90 allocs/op
BenchmarkSquirrelDelete-4                 299464              3984 ns/op            2536 B/op         61 allocs/op
PASS
ok      github.com/Masterminds/squirrel 14.009s
```