### PR TITLE
feat: add remove select builder columns method

### DIFF
--- a/select.go
+++ b/select.go
@@ -262,6 +262,13 @@ func (b SelectBuilder) Columns(columns ...string) SelectBuilder {
 	return builder.Extend(b, "Columns", parts).(SelectBuilder)
 }
 
+// RemoveColumns remove all columns from query.
+// Must add a new column with Column or Columns methods, otherwise
+// return a error.
+func (b SelectBuilder) RemoveColumns() SelectBuilder {
+	return builder.Delete(b, "Columns").(SelectBuilder)
+}
+
 // Column adds a result column to the query.
 // Unlike Columns, Column accepts args which will be bound to placeholders in
 // the columns string, for example:

--- a/select_test.go
+++ b/select_test.go
@@ -451,3 +451,13 @@ func ExampleSelectBuilder_ToSql() {
 		// scan...
 	}
 }
+
+func TestRemoveColumns(t *testing.T) {
+	query := Select("id").
+		From("users").
+		RemoveColumns()
+	query = query.Columns("name")
+	sql, _, err := query.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, "SELECT name FROM users", sql)
+}


### PR DESCRIPTION
I add remove columns method for select builder, it's useful for reuse others query conditions with others columns, e.g: use "COUNT(*)" feature before ( or after ) execute complex query conditions.