### PR TITLE
feat: add support for row (and optional column) aliases

### DIFF
--- a/insert_test.go
+++ b/insert_test.go
@@ -110,3 +110,22 @@ func TestInsertBuilderReplace(t *testing.T) {
 
 	assert.Equal(t, expectedSQL, sql)
 }
+
+func TestInsertBuilderValuesAlias(t *testing.T) {
+	b := Insert("").
+		Into("a").
+		Columns("b", "c").
+		Values(1, 2).
+		Values(3, Expr("? + 1", 4)).
+		RowAlias("new", "x", "z").
+		Suffix("ON DUPLICATE KEY UPDATE b = new.b")
+
+	sql, args, err := b.ToSql()
+	assert.NoError(t, err)
+
+	expectedSQL := "INSERT INTO a (b,c) VALUES (?,?),(?,? + 1) AS new(x,z) ON DUPLICATE KEY UPDATE b = new.b"
+	assert.Equal(t, expectedSQL, sql)
+
+	expectedArgs := []interface{}{1, 2, 3, 4}
+	assert.Equal(t, expectedArgs, args)
+}


### PR DESCRIPTION
Add support for MySQL 8's row alias


From the [MySQL 8 docs](https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html):

The use of [VALUES()](https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_values) to refer to the new row and columns is deprecated beginning with MySQL 8.0.20, and is subject to removal in a future version of MySQL.