### PR TITLE
feat: protect against accidental WHERE (1=1)

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -49,6 +49,10 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql.WriteString(d.From)
 
 	if len(d.WhereParts) > 0 {
+		if err := ensureWherePartIsNonEmptyMap(d.WhereParts); err != nil {
+			return "", nil, err
+		}
+
 		sql.WriteString(" WHERE ")
 		args, err = appendToSql(d.WhereParts, sql, " AND ", args)
 		if err != nil {

--- a/delete_test.go
+++ b/delete_test.go
@@ -80,9 +80,32 @@ func TestDeleteWithQuery(t *testing.T) {
 	assert.Equal(t, expectedSql, db.LastQuerySql)
 }
 
-func TestDeleteBuilderWhereNilMap(t *testing.T) {
-	m := make(map[string]interface{})
+func TestDeleteBuilderWhereNonNilMap(t *testing.T) {
 	db := &DBStub{}
+	m := map[string]interface{}{
+		"id": 55,
+	}
+
+	b := Delete("test").Where(m).RunWith(db)
+
+	expectedSql := "DELETE FROM test WHERE id = ?"
+	b.Query()
+
+	assert.Equal(t, expectedSql, db.LastQuerySql)
+}
+
+func TestDeleteBuilderWhereNilMap(t *testing.T) {
+	db := &DBStub{}
+	var m map[string]interface{}
+
+	b := Delete("test").Where(m).RunWith(db)
+	_, err := b.Exec()
+	assert.Equal(t, ErrUpdateOrDeleteWithNilMap, err)
+}
+
+func TestDeleteBuilderWhereEmptyMap(t *testing.T) {
+	db := &DBStub{}
+	m := make(map[string]interface{})
 
 	b := Delete("test").Where(m).RunWith(db)
 	_, err := b.Exec()

--- a/delete_test.go
+++ b/delete_test.go
@@ -79,3 +79,12 @@ func TestDeleteWithQuery(t *testing.T) {
 
 	assert.Equal(t, expectedSql, db.LastQuerySql)
 }
+
+func TestDeleteBuilderWhereNilMap(t *testing.T) {
+	m := make(map[string]interface{})
+	db := &DBStub{}
+
+	b := Delete("test").Where(m).RunWith(db)
+	_, err := b.Exec()
+	assert.Equal(t, ErrUpdateOrDeleteWithNilMap, err)
+}

--- a/squirrel.go
+++ b/squirrel.go
@@ -98,6 +98,11 @@ var RunnerNotSet = fmt.Errorf("cannot run; no Runner set (RunWith)")
 // RunnerNotQueryRunner is returned by QueryRow if the RunWith value doesn't implement QueryRower.
 var RunnerNotQueryRunner = fmt.Errorf("cannot QueryRow; Runner is not a QueryRower")
 
+// ErrUpdateOrDeleteWithNilMap is returned by Update or Delete queries when their Where
+// clause contains only a nil map. A nil map is evaluated to WHERE (1=1), which will cause
+// unexpected queries with an always-true WHERE clause.
+var ErrUpdateOrDeleteWithNilMap = fmt.Errorf("cannot update or delete with a nil map")
+
 // ExecWith Execs the SQL returned by s with db.
 func ExecWith(db Execer, s Sqlizer) (res sql.Result, err error) {
 	query, args, err := s.ToSql()

--- a/update.go
+++ b/update.go
@@ -101,6 +101,10 @@ func (d *updateData) ToSql() (sqlStr string, args []interface{}, err error) {
 	sql.WriteString(strings.Join(setSqls, ", "))
 
 	if len(d.WhereParts) > 0 {
+		if err := ensureWherePartIsNonEmptyMap(d.WhereParts); err != nil {
+			return "", nil, err
+		}
+
 		sql.WriteString(" WHERE ")
 		args, err = appendToSql(d.WhereParts, sql, " AND ", args)
 		if err != nil {

--- a/update_test.go
+++ b/update_test.go
@@ -83,9 +83,32 @@ func TestUpdateBuilderNoRunner(t *testing.T) {
 	assert.Equal(t, RunnerNotSet, err)
 }
 
-func TestUpdateBuilderWhereNilMap(t *testing.T) {
-	m := make(map[string]interface{})
+func TestUpdateBuilderWhereNonNilMap(t *testing.T) {
 	db := &DBStub{}
+	m := map[string]interface{}{
+		"id": 55,
+	}
+
+	b := Update("test").Set("x", 1).Where(m).RunWith(db)
+
+	expectedSql := "UPDATE test SET x = ? WHERE id = ?"
+	b.Query()
+
+	assert.Equal(t, expectedSql, db.LastQuerySql)
+}
+
+func TestUpdateBuilderWhereNilMap(t *testing.T) {
+	db := &DBStub{}
+	var m map[string]interface{}
+
+	b := Update("test").Set("x", 1).Where(m).RunWith(db)
+	_, err := b.Exec()
+	assert.Equal(t, ErrUpdateOrDeleteWithNilMap, err)
+}
+
+func TestUpdateBuilderWhereEmptyMap(t *testing.T) {
+	db := &DBStub{}
+	m := make(map[string]interface{})
 
 	b := Update("test").Set("x", 1).Where(m).RunWith(db)
 	_, err := b.Exec()

--- a/update_test.go
+++ b/update_test.go
@@ -82,3 +82,12 @@ func TestUpdateBuilderNoRunner(t *testing.T) {
 	_, err := b.Exec()
 	assert.Equal(t, RunnerNotSet, err)
 }
+
+func TestUpdateBuilderWhereNilMap(t *testing.T) {
+	m := make(map[string]interface{})
+	db := &DBStub{}
+
+	b := Update("test").Set("x", 1).Where(m).RunWith(db)
+	_, err := b.Exec()
+	assert.Equal(t, ErrUpdateOrDeleteWithNilMap, err)
+}

--- a/where.go
+++ b/where.go
@@ -28,3 +28,14 @@ func (p wherePart) ToSql() (sql string, args []interface{}, err error) {
 	}
 	return
 }
+
+func ensureWherePartIsNonEmptyMap(whereParts []Sqlizer) error {
+	if len(whereParts) == 1 {
+		if wp, ok := whereParts[0].(*wherePart); ok {
+			if _, ok := wp.pred.(map[string]interface{}); ok {
+				return ErrUpdateOrDeleteWithNilMap
+			}
+		}
+	}
+	return nil
+}

--- a/where.go
+++ b/where.go
@@ -32,8 +32,10 @@ func (p wherePart) ToSql() (sql string, args []interface{}, err error) {
 func ensureWherePartIsNonEmptyMap(whereParts []Sqlizer) error {
 	if len(whereParts) == 1 {
 		if wp, ok := whereParts[0].(*wherePart); ok {
-			if _, ok := wp.pred.(map[string]interface{}); ok {
-				return ErrUpdateOrDeleteWithNilMap
+			if m, ok := wp.pred.(map[string]interface{}); ok {
+				if len(m) == 0 {
+					return ErrUpdateOrDeleteWithNilMap
+				}
 			}
 		}
 	}


### PR DESCRIPTION
TL;DR: Adds a check to protect against accidental `WHERE (1=1)` clauses when executing an UPDATE or DELETE query with a nil or empty `Eq` map.

## Background

In #277, a user asked why passing a nil array in a `WHERE` clause creates a statement that contains `WHERE (1=0)`. The explanation there was that for compatibility between databases, that needs to evaluate to an "always false" statement. I think this is a good trade off, since it prevents potentially unexpected behaviour.

## Motivation

Unlike nil arrays, passing a nil or empty `Eq` map evaluates to an "always true" `WHERE` clause:

https://github.com/Masterminds/squirrel/blob/49f26833fcb82e3a493770a5a29d66d155289889/expr.go#L139-L144

While this is probably fine for `SELECT` or `INSERT` statements, I feel like this can cause unexpected and potentially dangerous `UPDATE` or `DELETE` statements.

For example, consider a `DELETE` query where the `Eq` map is populated conditionally:

```go
func DeleteByUserOrTeam(userID, teamID int64) {
	pred := make(map[string]interface{})
	if userID != 0 {
		pred["user_id"] = userID
	}
	if teamID != 0 {
		pred["team_id"] = teamID
	}

	sq.Delete("some_table").Where(pred).RunWith(db)
}
```

If this method is called as:

```go
DeleteByUserOrTeam(0, 0)
```

Squirrel currently generates the following MySQL query:

```sql
DELETE FROM some_table WHERE (1=1)
```

Which will delete every row in that table.

While the above example might not seem like something that would realistically happen (and should be caught easily with tests), for more complex predicate building logic, combined with some bad error handling, I would argue it's too easy to pass values that would end up creating a nil `Eq` map. It happened to me 😅 

## Proposed Solution

For `UPDATE` and `DELETE` queries, I've:
  * Added a check for a nil `Eq` map passed as the only argument to the `WHERE` clause,
  * Created a new error that is returned if that ever happens.
  * Added a new tests cases for this new behaviour.

I've tried to keep this PR as small as possible – this doesn't change the behaviour for passing `nil` to the where clause, or in any case where the predicate isn't a `map[string]interface{}` (passed using the `Eq` helper), and doesn't affect the behaviour for `INSERT` or `SELECT` queries.