### PR TITLE
Add USING clause to delete builder

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -19,6 +19,7 @@ type deleteData struct {
 	Limit             string
 	Offset            string
 	Suffixes          []Sqlizer
+	Usings            []string
 }
 
 func (d *deleteData) Exec() (sql.Result, error) {
@@ -47,6 +48,11 @@ func (d *deleteData) ToSql() (sqlStr string, args []interface{}, err error) {
 
 	sql.WriteString("DELETE FROM ")
 	sql.WriteString(d.From)
+
+	if len(d.Usings) > 0 {
+		sql.WriteString(" USING ")
+		sql.WriteString(strings.Join(d.Usings, ", "))
+	}
 
 	if len(d.WhereParts) > 0 {
 		sql.WriteString(" WHERE ")
@@ -188,4 +194,9 @@ func (d *deleteData) Query() (*sql.Rows, error) {
 		return nil, RunnerNotSet
 	}
 	return QueryWith(d.RunWith, d)
+}
+
+// Using adds an expression to the USING clause of the query
+func (b DeleteBuilder) Using(using ...string) DeleteBuilder {
+	return builder.Set(b, "Usings", using).(DeleteBuilder)
 }

--- a/delete_test.go
+++ b/delete_test.go
@@ -11,6 +11,12 @@ func TestDeleteBuilderToSql(t *testing.T) {
 		Prefix("WITH prefix AS ?", 0).
 		From("a").
 		Using("u2").
+		JoinClause("CROSS JOIN j1").
+		Join("j2").
+		LeftJoin("j3").
+		RightJoin("j4").
+		InnerJoin("j5").
+		CrossJoin("j6").
 		Where("b = ?", 1).
 		OrderBy("c").
 		Limit(2).
@@ -22,7 +28,9 @@ func TestDeleteBuilderToSql(t *testing.T) {
 
 	expectedSql :=
 		"WITH prefix AS ? " +
-			"DELETE FROM a USING u2 WHERE b = ? ORDER BY c LIMIT 2 OFFSET 3 " +
+			"DELETE FROM a USING u2 " +
+			"CROSS JOIN j1 JOIN j2 LEFT JOIN j3 RIGHT JOIN j4 INNER JOIN j5 CROSS JOIN j6 " +
+			"WHERE b = ? ORDER BY c LIMIT 2 OFFSET 3 " +
 			"RETURNING ?"
 	assert.Equal(t, expectedSql, sql)
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Masterminds/squirrel
+module github.com/kana-care/squirrel
 
 go 1.14
 

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -1,9 +1,9 @@
-module github.com/Masterminds/squirrel/integration
+module github.com/kana-care/squirrel/integration
 
 go 1.12
 
 require (
-	github.com/Masterminds/squirrel v1.1.0
+	github.com/kana-care/squirrel v1.1.0
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/lib/pq v1.2.0
 	github.com/mattn/go-sqlite3 v1.13.0
@@ -11,4 +11,4 @@ require (
 	google.golang.org/appengine v1.6.5 // indirect
 )
 
-replace github.com/Masterminds/squirrel => ../
+replace github.com/kana-care/squirrel => ../

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1,5 +1,5 @@
-github.com/Masterminds/squirrel v1.1.0 h1:baP1qLdoQCeTw3ifCdOq2dkYc6vGcmRdaociKLbEJXs=
-github.com/Masterminds/squirrel v1.1.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
+github.com/kana-care/squirrel v1.1.0 h1:baP1qLdoQCeTw3ifCdOq2dkYc6vGcmRdaociKLbEJXs=
+github.com/kana-care/squirrel v1.1.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-  sqrl "github.com/Masterminds/squirrel"
+	sqrl "github.com/kana-care/squirrel"
 
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
@@ -39,9 +39,9 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&dataSource, "dataSource", "", "integration database data source")
 	flag.Parse()
 
-  if driver == "" {
-    driver = "sqlite3"
-  }
+	if driver == "" {
+		driver = "sqlite3"
+	}
 
 	if driver == "sqlite3" && dataSource == "" {
 		dataSource = ":memory:"


### PR DESCRIPTION
Adds possibility to use the `USING` keyword in a delete query. This way, you can add an extra security check before deleting a record. 
For example, the table you want to delete from is has an ID as foreign key, but you want to check on a unique identifier as well, which is only present in the referenced table:
```
DELETE FROM playlist
USING song
WHERE 
    playlist.song_id = song.id AND
    song.id = 123 AND
    song.uuid = 'some-song-uuid'
```

You can use either one or multiple tables in the `Using()` builder:
```
sql, args, err := Delete("playlist").
Using("song", "user").
Where(And{
	Eq{"playlist.song_id": "song.id"},
	Eq{"playlist.user_id": "user.id"},
	Eq{"song.id": 123},
	Eq{"song.uuid": "some-song-uuid"},
	Eq{"user.id": 456},
	Eq{"user.uuid": "some-user-uuid"},
}).ToSql()
```
