### PR TITLE
feat: add arguments for From method in UpdateBuilder

### DIFF
--- a/update.go
+++ b/update.go
@@ -244,8 +244,8 @@ func (b UpdateBuilder) SetMap(clauses map[string]interface{}) UpdateBuilder {
 
 // From adds FROM clause to the query
 // FROM is valid construct in postgresql only.
-func (b UpdateBuilder) From(from string) UpdateBuilder {
-	return builder.Set(b, "From", newPart(from)).(UpdateBuilder)
+func (b UpdateBuilder) From(from string, args ...interface{}) UpdateBuilder {
+	return builder.Set(b, "From", newPart(from, args...)).(UpdateBuilder)
 }
 
 // FromSelect sets a subquery into the FROM clause of the query.

--- a/update_test.go
+++ b/update_test.go
@@ -89,6 +89,26 @@ func TestUpdateBuilderFrom(t *testing.T) {
 	assert.Equal(t, "UPDATE employees SET sales_count = ? FROM accounts WHERE accounts.name = ?", sql)
 }
 
+func TestUpdateBuilderParamFrom(t *testing.T) {
+	fromArgs := []interface{}{
+		1, 5,
+		2, 5,
+	}
+	sql, _, err := Update("employees").
+		Set("sales_count", Expr("c.sales_count")).
+		From("(VALUES (?, ?), (?, ?)) AS c(id, sales_count)", fromArgs...).
+		Where("id = c.id").
+		ToSql()
+	assert.NoError(t, err)
+
+	expectedSql :=
+		"UPDATE employees " +
+			"SET sales_count = c.sales_count " +
+			"FROM (VALUES (?, ?), (?, ?)) AS c(id, sales_count) " +
+			"WHERE id = c.id"
+	assert.Equal(t, expectedSql, sql)
+}
+
 func TestUpdateBuilderFromSelect(t *testing.T) {
 	sql, _, err := Update("employees").
 		Set("sales_count", 100).


### PR DESCRIPTION
This PR adds a new argument to the `From` method in the UpdateBuilder structure in Squirrel.
Currently, using the `UPDATE ... FROM ... VALUES` construction is only possible by manually appending SQL fragments with the `Suffix` method. This approach breaks the builder pattern and forces developers to continue the query construction using `Suffix` instead of other squirrel methods.

With this change, developers will be able to use the `From` method directly in UpdateBuilder, allowing full query composition through the standard Squirrel API.