### PR TITLE
feat: improved ReplacePlaceholders performance

### DIFF
--- a/placeholder.go
+++ b/placeholder.go
@@ -2,7 +2,6 @@ package squirrel
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 	"strings"
 )

--- a/placeholder.go
+++ b/placeholder.go
@@ -3,6 +3,7 @@ package squirrel
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -104,7 +105,8 @@ func replacePositionalPlaceholders(sql, prefix string) (string, error) {
 		} else {
 			i++
 			buf.WriteString(sql[:p])
-			fmt.Fprintf(buf, "%s%d", prefix, i)
+			buf.WriteString(prefix)
+			buf.WriteString(strconv.Itoa(i))
 			sql = sql[p+1:]
 		}
 	}

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -65,3 +65,11 @@ func BenchmarkPlaceholdersArray(b *testing.B) {
 func BenchmarkPlaceholdersStrings(b *testing.B) {
 	Placeholders(b.N)
 }
+
+func BenchmarkReplacePlaceholders(b *testing.B) {
+	var ph dollarFormat
+
+	for i := 0; i < b.N; i++ {
+		ph.ReplacePlaceholders("?")
+	}
+}


### PR DESCRIPTION
Changed use of fmt.Fprintf to strconv.Itoa
1. Perfomance increase by a factor of 3 (from ~150ns/op to ~50ns/op)
2. Cut allocations by half (from 4 to 2)